### PR TITLE
Support for nonbound reference lists

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -151,6 +151,20 @@ reference list.
 }}
 ```
 
+A nonbound reference list (for notes or additional literature references) that does
+not link to any of the `Citation reference` annotations directly in a page can be generated
+using the `|reference=` parameter.
+
+```
+{{#referencelist:
+ |listtype=ul
+ |browselinks=yes
+ |columns=1
+ |header=Notes
+ |references=PMC2483364;Einstein et al. 1935|+sep=;
+}}
+```
+
 ### References and citation keys
 
 Citation keys are available wiki-wide therefore selecting an

--- a/src/CacheKeyGenerator.php
+++ b/src/CacheKeyGenerator.php
@@ -14,7 +14,7 @@ class CacheKeyGenerator {
 	 * Update the version to force a recache for all items due to
 	 * required changes
 	 */
-	const VERSION = '1.0';
+	const VERSION = '1.1';
 
 	/**
 	 * @var string

--- a/src/CitationReferencePositionJournal.php
+++ b/src/CitationReferencePositionJournal.php
@@ -61,6 +61,39 @@ class CitationReferencePositionJournal {
 	}
 
 	/**
+	 * @note Build a journal from nonbound references (loose from the subject invoked
+	 * citation references), the position isn't important because those will not
+	 * be linked to any CiteRef anchors.
+	 *
+	 * @since 1.0
+	 *
+	 * @param  array $referenceList
+	 *
+	 * @return array|null
+	 */
+	public function buildJournalForNonboundReferenceList( array $referenceList ) {
+
+		if ( $referenceList === array() ) {
+			return null;
+		}
+
+		$journal = array(
+			'total' => 0,
+			'reference-list' => array(),
+			'reference-pos'  => array()
+		);
+
+		$journal['total'] = count( $referenceList );
+
+		foreach ( $referenceList as $reference ) {
+			$journal['reference-pos'][$reference] = array();
+			$journal['reference-list'][$reference] = $reference;
+		}
+
+		return $journal;
+	}
+
+	/**
 	 * @since 1.0
 	 *
 	 * @param DIWikiPage|null $subject

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -45,7 +45,7 @@ class HookRegistry {
 	}
 
 	/**
-	 * @note This is normally only used during unit/integration testing
+	 * @note Usually only used during unit/integration testing
 	 *
 	 * @since  1.0
 	 *

--- a/src/MediaWikiContextInteractor.php
+++ b/src/MediaWikiContextInteractor.php
@@ -105,4 +105,13 @@ class MediaWikiContextInteractor {
 		return $this->context->getTitle();
 	}
 
+	/**
+	 * @since 1.0
+	 *
+	 * @return string
+	 */
+	public function getLanguageCode() {
+		return $this->context->getLanguage()->getCode();
+	}
+
 }

--- a/src/ReferenceListFactory.php
+++ b/src/ReferenceListFactory.php
@@ -55,7 +55,6 @@ class ReferenceListFactory {
 
 		$mwCollaboratorFactory = ApplicationFactory::getInstance()->newMwCollaboratorFactory();
 		$htmlColumnListRenderer = $mwCollaboratorFactory->newHtmlColumnListRenderer();
-	//	$htmlColumnListRenderer->setColumnRTLDirectionalityState( $language->isRTL() );
 
 		$referenceListOutputRenderer = new ReferenceListOutputRenderer(
 			new CitationResourceMatchFinder( $this->store ),
@@ -82,7 +81,6 @@ class ReferenceListFactory {
 
 		$referenceListOutputRenderer = $this->newReferenceListOutputRenderer(
 			$parser
-	//		$contextInteractor->getTitle()->getPageLanguage()
 		);
 
 		$referenceListOutputRenderer->setNumberOfReferenceListColumns(

--- a/src/ReferenceListOutputRenderer.php
+++ b/src/ReferenceListOutputRenderer.php
@@ -124,14 +124,21 @@ class ReferenceListOutputRenderer {
 	 * @since 1.0
 	 *
 	 * @param DIWikiPage $subject
+	 * @param array|null $referenceList
 	 *
 	 * @return string
 	 */
-	public function renderReferenceListFor( DIWikiPage $subject ) {
+	public function renderReferenceListFor( DIWikiPage $subject, array $referenceList = null ) {
 
-		$journal = $this->citationReferencePositionJournal->getJournalBySubject(
-			$subject
-		);
+		if ( $referenceList !== null ) {
+			$journal = $this->citationReferencePositionJournal->buildJournalForNonboundReferenceList(
+				$referenceList
+			);
+		} else {
+			$journal = $this->citationReferencePositionJournal->getJournalBySubject(
+				$subject
+			);
+		}
 
 		if ( $journal !== null ) {
 			return $this->createHtmlFromList( $journal );
@@ -143,7 +150,7 @@ class ReferenceListOutputRenderer {
 	/**
 	 * The journal is expected to contain:
 	 *
-	 * 'total'      => a number
+	 * 'total' => a number
 	 * 'reference-list' => array of hashes for references used
 	 * 'reference-pos'  => individual reference links (1-a, 1-b) assigned to a hash
 	 */
@@ -153,6 +160,7 @@ class ReferenceListOutputRenderer {
 
 		foreach ( $referenceList['reference-pos'] as $referenceAsHash => $linkList ) {
 
+			$citationText = '';
 			// Get the "human" readable citation key/reference from the hashmap
 			// intead of trying to access the DB/Store
 			$reference = $referenceList['reference-list'][$referenceAsHash];
@@ -166,7 +174,11 @@ class ReferenceListOutputRenderer {
 				$referenceAsHash
 			);
 
-			$browseLinks = $this->createBrowseLinkFor( $subjects, $reference, $citationText );
+			$browseLinks = $this->createBrowseLinkFor(
+				$subjects,
+				$reference,
+				$citationText
+			);
 
 			$listOfFormattedReferences[] =
 				Html::rawElement(
@@ -176,14 +188,14 @@ class ReferenceListOutputRenderer {
 						'class' => 'scite-referencelinks'
 					),
 					$flatHtmlReferenceLinks
-					) . '&nbsp;'  .
+					) . ( $flatHtmlReferenceLinks !== '' ? '&nbsp;' : '' )  .
 				Html::rawElement(
 					'span',
 					array(
 						'id'    => 'scite-'. $referenceAsHash,
 						'class' => 'scite-citation'
 					),
-					$browseLinks . '&nbsp;' . Html::rawElement(
+					( $browseLinks !== '' ? $browseLinks . '&nbsp;' : '' ) . Html::rawElement(
 						'span',
 						array( 'class' => 'scite-citation-text' ),
 						$citationText

--- a/src/ReferenceListParserFunction.php
+++ b/src/ReferenceListParserFunction.php
@@ -16,8 +16,8 @@ class ReferenceListParserFunction {
 	/**
 	 * {{#referencelist:
 	 * |columns=2
-	 * |listType="ol"
-	 * |browseLinks=true
+	 * |listtype="ol"
+	 * |browselinks=true
 	 * }}
 	 *
 	 * @since 1.0
@@ -26,22 +26,42 @@ class ReferenceListParserFunction {
 	 */
 	public function doProcess( ParserParameterProcessor $parserParameterProcessor ) {
 
+		$header = '';
+
 		$attributes = array(
 			'id' => 'scite-custom-referencelist'
 		);
 
 		foreach ( $parserParameterProcessor->toArray() as $key => $values ) {
+
+			if ( $key === 'references' ) {
+				$attributes['data-references'] = json_encode( $values );
+				continue;
+			}
+
 			foreach ( $values as $value ) {
+
+				if ( $key === 'header' ) {
+					$header = $value;
+				}
+
 				$attributes['data-'. $key] = $value;
 			}
 		}
 
-		$html = Html::rawElement(
-			'div',
-			$attributes
+		$header = Html::element(
+			'h2',
+			array(),
+			$header
 		);
 
-		return $html;
+		$html = Html::rawElement(
+			'div',
+			$attributes,
+			$header
+		);
+
+		return $html . "<!-- end marker -->\n";
 	}
 
 }

--- a/tests/phpunit/Integration/Fixtures/scite-05-different-referencelist-position.json
+++ b/tests/phpunit/Integration/Fixtures/scite-05-different-referencelist-position.json
@@ -8,7 +8,7 @@
 		},
 		{
 			"name": "Citation/Reference/05/1",
-			"contents": "[[CiteRef::Foo:abc]] <div id=\"scite-custom-referencelist\"></div>"
+			"contents": "[[CiteRef::Foo:abc]] <div id=\"scite-custom-referencelist\"><h2></h2></div>"
 		},
 		{
 			"name": "Citation/Reference/05/2",

--- a/tests/phpunit/Integration/Fixtures/scite-09-nonbound-referencelist.json
+++ b/tests/phpunit/Integration/Fixtures/scite-09-nonbound-referencelist.json
@@ -1,0 +1,94 @@
+{
+	"description": "Testing {{#referencelist:}} to generate a loose reference list",
+	"properties": [],
+	"subjects": [
+		{
+			"name": "Citation/Resource/09",
+			"contents": "{{#scite:Foo:abc|type=text|citation text=Citation for bar}} {{#scite:Bar:abc|type=text|citation text=Citation for a loose reference}}"
+		},
+		{
+			"name": "Citation/Reference/09/1",
+			"contents": "[[CiteRef::Foo:abc]] {{#referencelist:listtype=ul}} \n {{#referencelist:listtype=ul|references=Bar:abc|header=Notes}}"
+		},
+		{
+			"name": "Citation/Reference/09/2",
+			"contents": "[[CiteRef::Foo:abc]] {{#referencelist:listtype=ul}} {{#referencelist:listtype=ul|references=Bar:abc|header=Notes}}"
+		},
+		{
+			"name": "Citation/Reference/09/3",
+			"contents": "{{#referencelist:listtype=ul|references=Bar:abc,Foo:abc|+sep=,|header=Notes}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 with new line",
+			"subject": "Citation/Reference/09/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "__sci_cite_reference", "_MDAT", "_SKEY" ],
+					"propertyValues": [ "Foo:abc" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"<div class=\"scite-content\"><h2 id=\"References\">References</h2>",
+					"<a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-backlink\" data-citeref-format=\"key\">^</a>",
+					"<span class=\"scite-citation-text\">Citation for bar</span>",
+					"<div class=\"scite-content\"><h2 id=\"Notes\">Notes</h2>",
+					"<span id=\"scite-Bar:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span>"
+				]
+			}
+		},
+		{
+			"about": "#1 without new line",
+			"subject": "Citation/Reference/09/2",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "__sci_cite_reference", "_MDAT", "_SKEY" ],
+					"propertyValues": [ "Foo:abc" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"<div class=\"scite-content\"><h2 id=\"References\">References</h2>",
+					"<a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-backlink\" data-citeref-format=\"key\">^</a>",
+					"<span class=\"scite-citation-text\">Citation for bar</span>",
+					"<div class=\"scite-content\"><h2 id=\"Notes\">Notes</h2>",
+					"<span id=\"scite-Bar:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span>"
+				]
+			}
+		},
+		{
+			"about": "#2 multiple",
+			"subject": "Citation/Reference/09/3",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [ "_MDAT", "_SKEY" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"<div class=\"scite-content\"><h2 id=\"Notes\">Notes</h2>",
+					"<span id=\"scite-Bar:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span>",
+					"<span id=\"scite-Foo:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for bar</span>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"scigReferenceListType": "ul",
+		"scigCitationReferenceCaptionFormat" : 2
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -176,6 +176,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$requestContext = $this->getMockBuilder( '\RequestContext' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -183,6 +187,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$requestContext->expects( $this->any() )
 			->method( 'getRequest' )
 			->will( $this->returnValue( $webRequest ) );
+
+		$requestContext->expects( $this->any() )
+			->method( 'getLanguage' )
+			->will( $this->returnValue( $language ) );
 
 		$requestContext->expects( $this->any() )
 			->method( 'getTitle' )


### PR DESCRIPTION
Sometimes it is necessary to extent/add a reference list with a
`Notes` section (additional literature etc.) that has no linked
citation references for the current page.

`#referencelist` adds the `|references=` parameter which enables to
generate a list of nonbound references.

```
{{#referencelist:
 |listtype=ul
 |browseLinks=yes
 |columns=1
 |header=Notes
 |references=PMC2483364;Einstein et al. 1935|+sep=;
}}
```