### PR TITLE
Add #scite bibtex import support

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -131,6 +131,40 @@ is the same as
   ...
 }}
 ```
+### bibtex import
+
+To easy the reuse of existing bibtex records, `#scite` provides the `|bibtex=` parameter to
+import a bibtex by simply adding its text and have `#scite` transform it into a structured form
+defined by the property and template rules.
+
+```
+{{#scite:
+ |bibtex=@ARTICLE{Meyer2000,
+AUTHOR="Bernd Meyer",
+TITLE="A constraint-based framework for diagrammatic reasoning",
+JOURNAL="Applied Artificial Intelligence",
+VOLUME= "14",
+ISSUE = "4",
+PAGES= "327--344",
+YEAR=2000
+}
+}}
+
+{{#scite:Einstein, Podolsky, and Nathan 1935
+ |bibtex=@article{einstein1935can,
+  title={Can quantum-mechanical description of physical reality be considered complete?},
+  author={Einstein, Albert and Podolsky, Boris and Rosen, Nathan},
+  journal={Physical review},
+  volume={47},
+  number={10},
+  pages={777},
+  year={1935},
+  publisher={APS}
+}
+ |authors=Albert Einstein, Boris Podolsky, Nathan Rosen|+sep=,
+}}
+```
+
 
 ### #referencelist usage
 
@@ -163,7 +197,7 @@ list is hidden) the parameter `|toc=yes` should be added to:
 }}
 ```
 
-To generate a nonbound reference list (for notes or additional literature references) 
+To generate a nonbound reference list (for notes or additional literature references)
 using the `|reference=` parameter is required because such list uses the information
 provided by `|reference=` and is not bound to any of the `Citation reference`
 annotations made to a particular page or subject.
@@ -208,10 +242,10 @@ appropriate key is paramount to safeguard against unnecessary changes.
 There are various ways of making different authors available to the semantic search
 and as ordered output.
 
-For example using a parameter `author` that is matched to a property `Has author`
-(to contain all authors in clear form) while an `authors` parameter (not matched to any
+For example using a parameter `authors` that is matched to a property `Has author`
+(to contain all authors in clear form) while an `author` parameter (not matched to any
 property) is used as identifier so that the template formatter can generate the expected
-ordered output from `{{{authors|}}}`  without having to apply a complex parsing process.
+ordered output from `{{{author|}}}`  without having to apply a complex parsing process.
 
 ```
 {{#scite:Watson and Crick, 1953

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ reuse of references stored within a wiki with support for:
 - Self-added and a customizable reference list
 - Individual property and text formatting rules
 - In-text reference tooltip
+- Bibtex record import support
 
 Semantic Cite does not require nor uses any part of [`Cite`][mw-cite] (or `<ref>`)
 as a means to declare a citation resource.

--- a/src/Bibtex/BibtexParser.php
+++ b/src/Bibtex/BibtexParser.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace SCI\Bibtex;
+
+/**
+ * @note most of the parsing code has been copied from PARSEENTRIES therefore
+ * thanks goes to the authors of http://bibliophile.sourceforge.net
+ *
+ * Comments to the source code can be found at
+ * http://sourceforge.net/projects/bibliophile/files/bibtexParse/ and be under
+ * under the GPL license.
+ *
+ * @note There might be a better parser out there but I didn't want to spend to
+ * much time reviewing code therefore PARSEENTRIES does the job well.
+ *
+ * Any fancy macro stuff or other complicated string parsing isn't supported
+ * given that the bibtex format misses a proper specification. PARSEENTRIES
+ * surely allows to cover more edge cases but for what we want to achieve (to ease
+ * copy and paste of existing bibtex records) the current implementation is
+ * sufficient.
+ *
+ * BibtexParserTest provides the test interface to verify edge cases.
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ */
+class BibtexParser {
+
+	/**
+	 * @var array
+	 */
+	private $undefinedStrings = array();
+
+	/**
+	 * @var array
+	 */
+	private $strings = array();
+
+	/**
+	 * @since  1.0
+	 *
+	 * Things like:
+	 * - "title = {{Stable theories}}" are not supported in MW since the parser
+	 *   replaces it with [[:Template:Stable theories]]
+	 */
+	public function parse( $bibtex ) {
+
+		$matches = preg_split("/@(.*)[{(](.*),/U", $bibtex, 2, PREG_SPLIT_DELIM_CAPTURE );
+
+		if( preg_match("/=/", $matches[2] ) ) {
+			$matches = preg_split("/@(.*)\s*[{(](.*)/U", $bibtex, 2, PREG_SPLIT_DELIM_CAPTURE );
+		}
+
+		$head = array(
+			'type'      => strtolower( trim( $matches[1] ) ),
+			'reference' => $matches[2]
+		);
+
+		return $head + $this->parseFields( $matches[3] );
+	}
+
+	private function parseFields( $content ) {
+		$elements = array();
+
+		$length = strlen( $content);
+
+		if( $content[$length - 1] == "}" ||  $content[$length - 1] == ")" ||  $content[$length - 1] == ",") {
+			$content = substr( $content,  0, $length - 1 );
+		}
+
+		$split = preg_split("/=/",  $content, 2 );
+		$string = $split[1];
+
+		while( $string ) {
+			list( $entry, $string ) = $this->splitField( $string );
+			$values[] = $entry;
+		}
+
+		foreach( $values as $value ) {
+			$pos = strpos( $content, $value);
+			$content = substr_replace( $content, '', $pos, strlen( $value ) );
+		}
+
+		$rev = strrev( trim( $content ) );
+
+		if( $rev{0} != ',') {
+			 $content .= ',';
+		}
+
+		$keys = preg_split("/=,/",  $content );
+		array_pop($keys);
+
+		foreach( $keys as $key ) {
+			$value = trim( array_shift( $values ) );
+			$rev = strrev( $value );
+
+			// remove any dangling ',' left on final field of entry
+			if($rev{0} == ',') {
+				$value = rtrim($value, ",");
+			}
+
+			if(!$value) {
+				continue;
+			}
+
+			$key = strtolower(trim($key));
+			$value = trim($value);
+			$elements[$key] = $this->removeDelimiters( $value );
+		}
+
+		return $elements;
+	}
+
+	private function splitField( $seg ) {
+
+		$array = preg_split("/,\s*([-_.:,a-zA-Z0-9]+)\s*={1}\s*/U", $seg, PREG_SPLIT_DELIM_CAPTURE );
+
+	//	if(!array_key_exists( 1, $array ) ) {
+	//		return array( $array[0], FALSE);
+	//	}
+
+		return isset( $array[1] ) ? array( $array[0], $array[1] ) : array( $array[0], false );
+	}
+
+	private function removeDelimiters( $string ) {
+
+		if( $string  && ( $string{0} == "\"") ) {
+			$string = substr($string, 1);
+			$string = substr($string, 0, -1);
+		} else if ( $string && ($string{0} == "{") ) {
+			if( strlen( $string ) > 0 && $string[strlen($string)-1] == "}" ) {
+				$string = substr($string, 1);
+				$string = substr($string, 0, -1);
+			}
+
+	//	} else if(!is_numeric($string) && !array_key_exists($string, $this->strings)
+	//		 && (array_search($string, $this->undefinedStrings) === FALSE ) ) {
+	//		$this->undefinedStrings[] = $string; // Undefined string that is not a year etc.
+	//		return '';
+		}
+
+		return $string;
+	}
+}

--- a/src/Bibtex/BibtexProcessor.php
+++ b/src/Bibtex/BibtexProcessor.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SCI\Bibtex;
+
+use SMW\ParserParameterProcessor;
+
+/**
+ * @license GNU GPL v2+
+ * @since 1.0
+ */
+class BibtexProcessor {
+
+	/**
+	 * @var BibtexParser
+	 */
+	private $bibtexParser;
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param BibtexParser $bibtexParser
+	 */
+	public function __construct( BibtexParser $bibtexParser ) {
+		$this->bibtexParser = $bibtexParser;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param ParserParameterProcessor $parserParameterProcessor
+	 */
+	public function doProcess( ParserParameterProcessor $parserParameterProcessor ) {
+
+		$bibtex = $parserParameterProcessor->getParameterValuesFor( 'bibtex' );
+
+		$parameters = $this->bibtexParser->parse( end( $bibtex ) );
+
+		foreach ( $parameters as $key => $value ) {
+
+			// The explicit reference precedes the one found in bibtex
+			if ( $key === 'reference' && $parserParameterProcessor->getFirstParameter() !== '' ) {
+				continue;
+			}
+
+			$parserParameterProcessor->addParameter(
+				$key,
+				$value
+			);
+		}
+	}
+
+}

--- a/src/CitationResourceMatchFinder.php
+++ b/src/CitationResourceMatchFinder.php
@@ -95,10 +95,10 @@ class CitationResourceMatchFinder {
 		while ( $resultArray = $queryResult->getNext() ) {
 			foreach ( $resultArray as $result ) {
 
-				// Collect all matches for the same reference because it can happen
+				// Collect all subjects for the same reference because it can happen
 				// that the same reference key is used for different citation
-				// resources therefore we only return one (the last) valid citation
-				// text but nevertheless return all subjects to make easier to find them
+				// resources therefore only return one (the last) valid citation
+				// text but return all subjects to make it easier to find them later
 				$subjects[] = $result->getResultSubject();
 
 				while ( ( $dataValue = $result->getNextDataValue() ) !== false ) {
@@ -111,6 +111,8 @@ class CitationResourceMatchFinder {
 	}
 
 	/**
+	 * Find match for [[Citation key::SomeKey]]|?Citation text
+	 *
 	 * @since 1.0
 	 *
 	 * @param string $citationReference

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -5,6 +5,8 @@ namespace SCI;
 use SMW\ApplicationFactory;
 use SMW\NamespaceExaminer;
 use SMW\ParameterProcessorFactory;
+use SCI\Bibtex\BibtexProcessor;
+use SCI\Bibtex\BibtexParser;
 
 /**
  * @license GNU GPL v2+
@@ -48,7 +50,8 @@ class ParserFunctionFactory {
 				$parserData,
 				$namespaceExaminer,
 				$citationTextTemplateRenderer,
-				$mediaWikiNsContentMapper
+				$mediaWikiNsContentMapper,
+				new BibtexProcessor( new BibtexParser() )
 			);
 
 			$sciteParserFunction->setStrictParserValidationState(

--- a/tests/phpunit/Integration/ByJsonParserTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonParserTestCaseRunnerTest.php
@@ -43,6 +43,11 @@ class ByJsonParserTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'cachePrefix'                      => 'foo'
 		);
 
+		// This is to ensure we read from the DB when a test case
+		// specifies a NS_MEDIAWIKI page
+		MediaWikiNsContentMapper::clear();
+		MediaWikiNsContentMapper::$skipMessageCache = true;
+
 		$cacheFactory = new CacheFactory();
 
 		$this->hookRegistry = new HookRegistry(
@@ -113,9 +118,6 @@ class ByJsonParserTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			$jsonTestCaseFileHandler->getListOfSubjects(),
 			NS_MAIN
 		);
-
-		MediaWikiNsContentMapper::clear();
-		MediaWikiNsContentMapper::$skipMessageCache = true;
 
 		foreach ( $jsonTestCaseFileHandler->findTestCasesFor( 'parser-testcases' ) as $case ) {
 

--- a/tests/phpunit/Integration/Fixtures/scite-13-bibtex-property-mapping.json
+++ b/tests/phpunit/Integration/Fixtures/scite-13-bibtex-property-mapping.json
@@ -1,0 +1,98 @@
+{
+	"description": "Test bibtex property mapping",
+	"properties": [
+		{
+			"name": "Has reference type",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"name": "Has author",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"name": "Has title",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"name": "Has abstract",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"name": "Has publisher",
+			"contents": "[[Has type::Text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Sci-property-definition",
+			"namespace": "NS_MEDIAWIKI",
+			"contents": "Some assignments\n type|Has reference type \n author|Has author \n authors|Has author \n title|Has title \n journal|Has publisher \n abstract|Has abstract\n"
+		},
+		{
+			"name": "Sci-template-definition",
+			"namespace": "NS_MEDIAWIKI",
+			"contents": "Some type-template assignments\n article|SciteArticleFormatter \n"
+		},
+		{
+			"name": "SciteArticleFormatter",
+			"namespace": "NS_TEMPLATE",
+			"contents": "<includeonly>{{{title}}}</includeonly>"
+		},
+		{
+			"name": "Example/12/1",
+			"contents": "{{#scite:\n |bibtex=@ARTICLE{Meyer2000,\nAUTHOR=\"Bernd Meyer\",\nTITLE=\"A constraint-based framework for diagrammatic reasoning\",\nJOURNAL=\"Applied Artificial Intelligence\",\nVOLUME= \"14\",\nISSUE = \"4\",\nPAGES= \"327--344\",\nYEAR=2000\n}\n |citation text=2000}}"
+		},
+		{
+			"name": "Example/12/2",
+			"contents": "{{#scite:Einstein, Podolsky, and Nathan 1935\n |bibtex=@article{einstein1935can,\n  title={Can quantum-mechanical description of physical reality be considered complete?},\n  author={Einstein, Albert and Podolsky, Boris and Rosen, Nathan},\n  journal={Physical review},\n  volume={47},\n  number={10},\n  pages={777},\n  year={1935},\n  publisher={APS}\n}\n |authors=Albert Einstein, Boris Podolsky, Nathan Rosen|+sep=,\n}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/12/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "__sci_cite", "_MDAT", "_SKEY" ],
+					"propertyValues": [ "Example/12/1#_SCITE-7a0c0a939e8181da78d3ebe6cf09eeca" ]
+				}
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/12/1#_SCITE-7a0c0a939e8181da78d3ebe6cf09eeca",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 7,
+					"propertyKeys": [ "__sci_cite_key", "__sci_cite_text", "Has_author", "Has_title", "Has_publisher", "Has_reference_type", "_SKEY" ],
+					"propertyValues": [ "article", "Meyer2000", "Bernd Meyer", "A constraint-based framework for diagrammatic reasoning", "Applied Artificial Intelligence" ]
+				}
+			}
+		},
+		{
+			"about": "#2 with separated authors",
+			"subject": "Example/12/2#_SCITE-b9a7caa631427c26f4c8e70219b2cda9",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 7,
+					"propertyKeys": [ "__sci_cite_key", "__sci_cite_text", "Has_author", "Has_title", "Has_publisher", "Has_reference_type", "_SKEY" ],
+					"propertyValues": [ "article", "Einstein, Podolsky, and Nathan 1935", "Albert Einstein", "Boris Podolsky", "Nathan Rosen", "Can quantum-mechanical description of physical reality be considered complete?", "Physical review" ]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"scigReferenceListType": "ol",
+		"scigCitationReferenceCaptionFormat" : 1
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Bibtex/BibtexParserTest.php
+++ b/tests/phpunit/Unit/Bibtex/BibtexParserTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace SCI\Tests\Bibtex;
+
+use SCI\Bibtex\BibtexParser;
+
+/**
+ * @covers \SCI\Bibtex\BibtexParser
+ * @group semantic-citation
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class BibtexParserTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SCI\Bibtex\BibtexParser',
+			new BibtexParser()
+		);
+	}
+
+	/**
+	 * @dataProvider bibtextProvider
+	 */
+	public function testParse( $bibtex, $expected ) {
+
+		$instance = new BibtexParser();
+
+		$this->assertEquals(
+			$expected,
+			$instance->parse( $bibtex )
+		);
+	}
+
+	public function bibtextProvider() {
+
+		$provider[] = array(
+			"@article{einstein1935can,
+			  title={Can quantum-mechanical description of physical reality be considered complete?},
+			  author={Einstein, Albert and Podolsky, Boris and Rosen, Nathan},
+			  journal={Physical review},
+			  volume={47},
+			  number={10},
+			  pages={777},
+			  year={1935},
+			  publisher={APS}
+			}",
+			array(
+				'type'      => 'article',
+				'reference' => 'einstein1935can',
+				'title'     => 'Can quantum-mechanical description of physical reality be considered complete?',
+				'author'    => 'Einstein, Albert and Podolsky, Boris and Rosen, Nathan',
+				'journal'   => 'Physical review',
+				'volume'    => '47',
+				'number'    => '10',
+				'pages'     => '777',
+				'year'      => '1935',
+				'publisher' => 'APS'
+			)
+		);
+
+		$provider[] = array(
+			"@book{marx2004capital,
+			  title={Capital (Volume 1: A Critique of Political Economy): A Critique of Political Economy},
+			  author={Marx, Karl},
+			  year={2004},
+			  publisher={Digireads. com Publishing}
+			}",
+			array(
+				'type'      => 'book',
+				'reference' => 'marx2004capital',
+				'title'     => 'Capital (Volume 1: A Critique of Political Economy): A Critique of Political Economy',
+				'author'    => 'Marx, Karl',
+				'year'      => '2004',
+				'publisher' => 'Digireads. com Publishing'
+			)
+		);
+
+		#2 No reference
+		$provider[] = array(
+			"@article{,
+			  title={Vascular endothelial growth factor is a secreted angiogenic mitogen},
+			  author={Leung, David W and Cachianes, George and Kuang, Wun-Jing and Goeddel, David V and Ferrara, Napoleone},
+			  journal={Science},
+			  volume={246},
+			  number={4935},
+			  pages={1306--1309},
+			  year={1989},
+			  publisher={American Association for the Advancement of Science}
+			}",
+			array(
+				'type'      => 'article',
+				'reference' => '',
+				'title'     => 'Vascular endothelial growth factor is a secreted angiogenic mitogen',
+				'author'    => 'Leung, David W and Cachianes, George and Kuang, Wun-Jing and Goeddel, David V and Ferrara, Napoleone',
+				'journal'   => 'Science',
+				'volume'    => '246',
+				'number'    => '4935',
+				'pages'     => '1306--1309',
+				'year'      => '1989',
+				'publisher' => 'American Association for the Advancement of Science'
+			)
+		);
+
+		#3 No reference
+		$provider[] = array(
+			"@inproceedings{clean,
+			  author = {First Author and Author, Second},
+			  title = {Pr{\"a}diktive Teilbandcodierung mit Vektorquantisierung f{\"u}r hochqualitative Audiosignale},
+			  booktitle = {8. ITG-Fachtagung H{\"o}rrundfunk},
+			  year = {1988},
+			  month = nov,
+			  pages = {252--256},
+			  abstract = {Some Abstract, across
+			two lines},
+			}",
+			array(
+				'type'      => 'inproceedings',
+				'reference' => 'clean',
+				'author'    => 'First Author and Author, Second',
+				'title'     => 'Pr{"a}diktive Teilbandcodierung mit Vektorquantisierung f{"u}r hochqualitative Audiosignale',
+				'booktitle' => '8. ITG-Fachtagung H{"o}rrundfunk',
+				'year'      => '1988',
+				'month'     => 'nov',
+				'pages'     => '252--256',
+				'abstract'  => "Some Abstract, across
+			two lines"
+			)
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Bibtex/BibtexProcessorTest.php
+++ b/tests/phpunit/Unit/Bibtex/BibtexProcessorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SCI\Tests\Bibtex;
+
+use SCI\Bibtex\BibtexProcessor;
+
+/**
+ * @covers \SCI\Bibtex\BibtexProcessor
+ * @group semantic-citation
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class BibtexProcessorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$bibtexParser = $this->getMockBuilder( '\SCI\Bibtex\BibtexParser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SCI\Bibtex\BibtexProcessor',
+			new BibtexProcessor( $bibtexParser )
+		);
+	}
+
+	public function testDoProcess() {
+
+		$bibtexParser = $this->getMockBuilder( '\SCI\Bibtex\BibtexParser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$bibtexParser->expects( $this->once() )
+			->method( 'parse' )
+			->will( $this->returnValue( array( 'Foo' => 'Bar' ) ) );
+
+		$parserParameterProcessor = $this->getMockBuilder( '\SMW\ParserParameterProcessor' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserParameterProcessor->expects( $this->once() )
+			->method( 'getParameterValuesFor' )
+			->with(	$this->equalTo( 'bibtex' ) )
+			->will( $this->returnValue( array() ) );
+
+		$parserParameterProcessor->expects( $this->once() )
+			->method( 'addParameter' )
+			->with(
+				$this->equalTo( 'Foo' ),
+				$this->equalTo( 'Bar' ) );
+
+		$instance = new BibtexProcessor( $bibtexParser );
+
+		$instance->doProcess(
+			$parserParameterProcessor
+		);
+	}
+
+}


### PR DESCRIPTION
Add support for bibtex import via `#scite` for creating citation resources as easy as copy-and-paste into a structured format.

Code in `BibtexParser`comes from PARSEENTRIES[0]

[0] http://bibliophile.sourceforge.net

## Examples

```
{{#scite:
 |bibtex=@article{Sh:2,
author = {Shelah, Saharon},
ams-subject = {(05.04)},
journal = {Journal of Combinatorial Theory},
review = {MR 39-2652},
pages = {298--300},
title = {Note on a min-max problem of Leo Moser},
volume = {6},
year = {1969},
}
}}

{{#scite:
 |bibtex=@ARTICLE{Meyer2000,
AUTHOR="Bernd Meyer",
TITLE="A constraint-based framework for diagrammatic reasoning",
JOURNAL="Applied Artificial Intelligence",
VOLUME= "14",
ISSUE = "4",
PAGES= "327--344",
YEAR=2000
}
}}
```
![image](https://cloud.githubusercontent.com/assets/1245473/8576599/72531df4-25a3-11e5-95be-7c6b2913dba2.png)

![image](https://cloud.githubusercontent.com/assets/1245473/8576540/1ab5d92e-25a3-11e5-9b03-1f2dfcffda2d.png)