### PR TITLE
Add citation reference backlinks to Special:Browse

### DIFF
--- a/src/BrowsePropertyLookup.php
+++ b/src/BrowsePropertyLookup.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SCI;
+
+use SMW\Store;
+use SMW\SemanticData;
+use SMW\DIProperty;
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMWQuery as Query;
+
+/**
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class BrowsePropertyLookup {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var integer
+	 */
+	private $limit = 20;
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param SemanticData $semanticData
+	 */
+	public function addReferenceBacklinks( SemanticData $semanticData, $requestOptions = null ) {
+
+		$keys = $this->store->getSemanticData( $semanticData->getSubject() )->getPropertyValues(
+			new DIProperty( '__sci_cite_key' )
+		);
+
+		// Not a resource that contains a citation key
+		if ( $keys === null || $keys === array() ) {
+			return null;
+		}
+
+		if ( isset( $requestOptions->limit ) && $requestOptions->limit > 0 ) {
+			$this->limit = $requestOptions->limit;
+		}
+
+		$property = new DIProperty( '__sci_cite_reference' );
+
+		foreach ( $this->findReferenceBacklinksFor( end( $keys ) ) as $subject ) {
+			$semanticData->addPropertyObjectValue( $property, $subject );
+		}
+	}
+
+	private function findReferenceBacklinksFor( $key ) {
+
+		$property = new DIProperty( '__sci_cite_reference' );
+
+		$description = new ValueDescription(
+			$key,
+			$property
+		);
+
+		$someProperty = new SomeProperty(
+			$property,
+			$description
+		);
+
+		$query = new Query( $someProperty );
+		$query->setLimit( $this->limit );
+
+		return $this->store->getQueryResult( $query )->getResults();
+	}
+
+}

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -152,6 +152,21 @@ class HookRegistry {
 		};
 
 		/**
+		 * @see https://www.semantic-mediawiki.org/wiki/Hooks/SMW::Browse::AfterInPropertiesLookupComplete
+		 */
+		$this->handlers['SMW::Browse::AfterInPropertiesLookupComplete'] = function ( $store, $semanticData, $requestOptions ) {
+
+			$browsePropertyLookup = new BrowsePropertyLookup( $store );
+
+			$browsePropertyLookup->addReferenceBacklinks(
+				$semanticData,
+				$requestOptions
+			);
+
+			return true;
+		};
+
+		/**
 		 * @see https://www.semantic-mediawiki.org/wiki/Hooks/SMW::Parser::BeforeMagicWordsFinder
 		 */
 		$this->handlers['SMW::Parser::BeforeMagicWordsFinder'] = function( array &$magicWords ) {

--- a/tests/phpunit/Unit/BrowsePropertyLookupTest.php
+++ b/tests/phpunit/Unit/BrowsePropertyLookupTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SCI\Tests;
+
+use SCI\BrowsePropertyLookup;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SCI\BrowsePropertyLookup
+ * @group semantic-cite
+ *
+ * @license GNU GPL v2+
+ * @since   1.0
+ *
+ * @author mwjames
+ */
+class BrowsePropertyLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->assertInstanceOf(
+			'\SCI\BrowsePropertyLookup',
+			new BrowsePropertyLookup( $store )
+		);
+	}
+
+	public function testAddReferenceBacklinks() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ ) ) );
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( DIWikiPage::newFromText( 'Bar' ) ) ) );
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'addPropertyObjectValue' );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->once() )
+			->method( 'getResults' )
+			->will( $this->returnValue( array( DIWikiPage::newFromText( 'Foo' ) ) ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'getQueryResult' )
+			->will( $this->returnValue( $queryResult ) );
+
+		$store->expects( $this->once() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$instance = new BrowsePropertyLookup( $store );
+
+		$instance->addReferenceBacklinks(
+			$semanticData
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -65,19 +65,20 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			new Options( $configuration )
 		);
 
-		$this->doTestRegistereddInitPropertiesHandler( $instance );
-		$this->doTestRegistereddInitDataTypesHandler( $instance );
-		$this->doTestRegistereddBeforeMagicWordsFinderHandler( $instance );
-		$this->doTestRegistereddOutputPageParserOutput( $instance );
-		$this->doTestRegistereddOutputPageBeforeHTML( $instance );
-		$this->doTestRegistereddUpdateDataBefore( $instance );
-		$this->doTestRegistereddAddCustomFixedPropertyTables( $instance );
+		$this->doTestRegisteredInitPropertiesHandler( $instance );
+		$this->doTestRegisteredInitDataTypesHandler( $instance );
+		$this->doTestRegisteredBeforeMagicWordsFinderHandler( $instance );
+		$this->doTestRegisteredOutputPageParserOutput( $instance );
+		$this->doTestRegisteredOutputPageBeforeHTML( $instance );
+		$this->doTestRegisteredUpdateDataBefore( $instance );
+		$this->doTestRegisteredAddCustomFixedPropertyTables( $instance );
 		$this->doTestRegisteredResourceLoaderGetConfigVars( $instance );
 		$this->doTestRegisteredParserFirstCallInit( $instance );
 		$this->doTestRegisteredBeforePageDisplay( $instance );
+		$this->doTestRegisteredBrowseAfterInPropertiesLookupComplete( $instance );
 	}
 
-	public function doTestRegistereddInitPropertiesHandler( $instance ) {
+	public function doTestRegisteredInitPropertiesHandler( $instance ) {
 
 		$hook = 'SMW::Property::initProperties';
 
@@ -95,7 +96,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function doTestRegistereddInitDataTypesHandler( $instance ) {
+	public function doTestRegisteredInitDataTypesHandler( $instance ) {
 
 		$hook = 'SMW::DataType::initTypes';
 
@@ -146,7 +147,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function doTestRegistereddBeforeMagicWordsFinderHandler( $instance ) {
+	public function doTestRegisteredBeforeMagicWordsFinderHandler( $instance ) {
 
 		$hook = 'SMW::Parser::BeforeMagicWordsFinder';
 
@@ -162,7 +163,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function doTestRegistereddOutputPageParserOutput( $instance ) {
+	public function doTestRegisteredOutputPageParserOutput( $instance ) {
 
 		$hook = 'OutputPageParserOutput';
 
@@ -184,7 +185,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function doTestRegistereddOutputPageBeforeHTML( $instance ) {
+	public function doTestRegisteredOutputPageBeforeHTML( $instance ) {
 
 		$hook = 'OutputPageBeforeHTML';
 
@@ -232,7 +233,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function doTestRegistereddUpdateDataBefore( $instance ) {
+	public function doTestRegisteredUpdateDataBefore( $instance ) {
 
 		$hook = 'SMWStore::updateDataBefore';
 
@@ -258,7 +259,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function doTestRegistereddAddCustomFixedPropertyTables( $instance ) {
+	public function doTestRegisteredAddCustomFixedPropertyTables( $instance ) {
 
 		$hook = 'SMW::SQLStore::AddCustomFixedPropertyTables';
 
@@ -331,6 +332,36 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $hook ),
 			array( &$outputPage, &$skin )
+		);
+	}
+
+	public function doTestRegisteredBrowseAfterInPropertiesLookupComplete( $instance ) {
+
+		$hook = 'SMW::Browse::AfterInPropertiesLookupComplete';
+
+		$this->assertTrue(
+			$instance->isRegistered( $hook )
+		);
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( \SMW\DIWikiPage::newFromText( __METHOD__ ) ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $hook ),
+			array( $store, $semanticData, null )
 		);
 	}
 


### PR DESCRIPTION
Generates backlinks to subjects that use a selected citation resource (and make use of the `Citation reference` property).

![image](https://cloud.githubusercontent.com/assets/1245473/8960192/1c366a1c-360f-11e5-9a2d-dc1afcf687d7.png)

Requires https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/f248f9f2e296e29e949ddf19f90637f06b4793fd