### PR TITLE
Add BibtexAuthorListParser

### DIFF
--- a/docs/04-scite.md
+++ b/docs/04-scite.md
@@ -19,7 +19,7 @@ besides those listed below:
 - Other reserved parameters include `doi`, `pmcid`, `pmid`, `olid`, `oclc`, and `viaf` linking
   to its representing property
 
-### Citation key (unique indentifiers)
+### Citation key
 
 A citation resource is expected to be identifiable by a unique key and to be available
 wiki-wide therefore selecting an appropriate key is paramount to safeguard against
@@ -53,7 +53,7 @@ is set `false`.
 If something like `|type=bgn:Thesis;schema:Book|+sep=;` has been generated or specified then
 the last entry (e.g. `schema:Book`) will be selected as valid descriptor.
 
-### Bibtex import
+### Bibtex record import
 
 To ease the reuse of bibtex records, `#scite` provides the `|bibtex=` parameter to
 import a bibtex record as text which `#scite` will transform into a structured form
@@ -72,8 +72,15 @@ YEAR=2000
 }
 }}
 ```
+
+#### Authors
+
+Authors (e.g. `Einstein, Albert and Podolsky, Boris and Rosen, Nathan`) will be split
+into an author list of natural representations (`Albert Einstein` etc.) while the original
+annotation text is still available using the hidden `bibtex-author` parameter.
+
 ```
-{{#scite:Einstein, Podolsky, and Nathan 1935
+{{#scite:
  |bibtex=@article{einstein1935can,
   title={Can quantum-mechanical description of physical reality be considered complete?},
   author={Einstein, Albert and Podolsky, Boris and Rosen, Nathan},
@@ -84,9 +91,11 @@ YEAR=2000
   year={1935},
   publisher={APS}
 }
- |authors=Albert Einstein, Boris Podolsky, Nathan Rosen|+sep=,
 }}
 ```
+
+#### Formatting
+
 ```
 {{#scite:
  |bibtex=@article{Marshakov:2010si,

--- a/src/Bibtex/BibtexAuthorListParser.php
+++ b/src/Bibtex/BibtexAuthorListParser.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace SCI\Bibtex;
+
+/**
+ * @note most of the parsing code has been copied from PARSECREATORS therefore
+ * thanks goes to the authors of http://bibliophile.sourceforge.net
+ *
+ * Comments to the source code can be found at
+ * http://sourceforge.net/projects/bibliophile/files/bibtexParse/ released under
+ * under the GPL license.
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ */
+class BibtexAuthorListParser {
+
+	/**
+	 * @var array
+	 */
+	private $prefix = array();
+
+	/**
+	 * Create writer arrays from bibtex input
+	 *
+	 * 'author field can be (delimiters between authors are 'and' or '&'):
+	 * 1. <first-tokens> <von-tokens> <last-tokens>
+	 * 2. <von-tokens> <last-tokens>, <first-tokens>
+	 * 3. <von-tokens> <last-tokens>, <jr-tokens>, <first-tokens>
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $input
+	 *
+	 * @return array
+	 */
+	public function parse( $input ) {
+
+		$authorList = array();
+
+		// split on ' and '
+		$authorArray = preg_split("/\s(and|&)\s/i", trim( $input ) );
+
+		foreach( $authorArray as $value ) {
+			$appellation = '';
+			$prefix = '';
+
+			$surname = '';
+			$initials = '';
+
+			$this->prefix = array();
+
+			$author = explode( ",", preg_replace("/\s{2,}/", ' ', trim( $value ) ) );
+			$size = count( $author );
+
+			// No commas therefore something like Mark Grimshaw, Mark Nicholas Grimshaw, M N Grimshaw, Mark N. Grimshaw
+			if( $size == 1 ) {
+				// Is complete surname enclosed in {...}, unless the string starts with a backslash (\) because then it is
+				// probably a special latex-sign..
+				// 2006.02.11 DR: in the last case, any NESTED curly braces should also be taken into account! so second
+				// clause rules out things such as author="a{\"{o}}"
+				//
+				if( preg_match("/(.*){([^\\\].*)}/", $value, $matches) &&
+					!(preg_match("/(.*){\\\.{.*}.*}/", $value, $matches2 ) ) ) {
+					$author = explode(" ", $matches[1]);
+					$surname = $matches[2];
+				} else {
+					$author = explode(" ", $value);
+					// last of array is surname (no prefix if entered correctly)
+					$surname = array_pop($author);
+				}
+			} elseif( $size == 2 ) { // Something like Grimshaw, Mark or Grimshaw, Mark Nicholas  or Grimshaw, M N or Grimshaw, Mark N.
+				// first of array is surname (perhaps with prefix)
+				list( $surname, $prefix ) = $this->grabSurname( array_shift( $author ) );
+			} else { // If $size is 3, we're looking at something like Bush, Jr. III, George W
+				// middle of array is 'Jr.', 'IV' etc.
+				$appellation = implode(' ', array_splice( $author, 1, 1 ) );
+				// first of array is surname (perhaps with prefix)
+				list( $surname, $prefix ) = $this->grabSurname( array_shift( $author ) );
+			}
+
+			$remainder = implode( " ", $author );
+
+			list( $firstname, $initials ) = $this->grabFirstnameInitials( $remainder );
+
+			if( $this->prefix !== array() ) {
+				$prefix = implode(' ', $this->prefix );
+			}
+
+			$surname = $surname . ' ' . trim( $appellation );
+
+			$authorList[] = $this->concatenate( $firstname, $initials, $surname, $prefix );
+		}
+
+		return $authorList;
+	}
+
+	private function concatenate( $firstname, $initials, $surname, $prefix ) {
+
+		$author = array(
+			trim( $firstname ),
+			trim( $initials ),
+			trim( $prefix ),
+			trim( $surname )
+		);
+
+		return implode( ' ', array_filter( $author ) );
+	}
+
+	/**
+	 * @note firstname and initials which may be of form "A.B.C." or "A. B. C. " or " A B C " etc.
+	 */
+	private function grabFirstnameInitials( $remainder ) {
+
+		$array = explode( " ", $remainder );
+
+		$firstname = '';
+		$initials = '';
+
+		$initialsArray = array();
+		$firstnameArray = array();
+
+		foreach( $array as $value ) {
+			$firstChar = substr($value, 0, 1);
+
+			if( ( ord( $firstChar ) >= 97 ) && ( ord( $firstChar ) <= 122) ) {
+				$this->prefix[] = $value;
+			} elseif( preg_match("/[a-zA-Z]{2,}/", trim( $value ) ) ) {
+				$firstnameArray[] = trim($value);
+			} else {
+				$initialsArray[] = str_replace(".", " ", trim( $value ) );
+			}
+		}
+
+		foreach( $initialsArray as $initial) {
+			$initials .= ' ' . trim ( $initial );
+		}
+
+		$firstname = implode(" ", $firstnameArray);
+
+		return array( $firstname, $initials );
+	}
+
+	/**
+	 * @note surname may have title such as 'den', 'von', 'de la' etc. -
+	 * characterised by first character lowercased.  Any uppercased part means
+	 * lowercased parts following are part of the surname (e.g. Van den Bussche)
+	 */
+	private function grabSurname( $input ) {
+		$surnameArray = explode(" ", $input );
+
+		$noPrefix = false;
+		$surname = array();
+		$prefix = array();
+
+		foreach( $surnameArray as $value ) {
+			$firstChar = substr($value, 0, 1);
+
+			if( !$noPrefix && ( ord( $firstChar ) >= 97 ) && ( ord( $firstChar ) <= 122 ) ) {
+				$prefix[] = $value;
+			} else {
+				$surname[] = $value;
+				$noPrefix = TRUE;
+			}
+		}
+
+		$surname = implode(" ", $surname);
+
+		if( $prefix !== array() ) {
+			return array( $surname, implode(" ", $prefix ) );
+		}
+
+		return array( $surname, false );
+	}
+}

--- a/src/Bibtex/BibtexProcessor.php
+++ b/src/Bibtex/BibtexProcessor.php
@@ -16,12 +16,19 @@ class BibtexProcessor {
 	private $bibtexParser;
 
 	/**
+	 * @var BibtexAuthorListParser
+	 */
+	private $bibtexAuthorListParser;
+
+	/**
 	 * @since 1.0
 	 *
 	 * @param BibtexParser $bibtexParser
+	 * @param BibtexAuthorListParser $bibtexAuthorListParser
 	 */
-	public function __construct( BibtexParser $bibtexParser ) {
+	public function __construct( BibtexParser $bibtexParser, BibtexAuthorListParser $bibtexAuthorListParser ) {
 		$this->bibtexParser = $bibtexParser;
+		$this->bibtexAuthorListParser = $bibtexAuthorListParser;
 	}
 
 	/**
@@ -46,6 +53,18 @@ class BibtexProcessor {
 
 			if ( $key === 'type' && $parserParameterProcessor->hasParameter( 'type' ) ) {
 				continue;
+			}
+
+			if ( $key === 'author' ) {
+
+				$parserParameterProcessor->setParameter(
+					$key,
+					$this->bibtexAuthorListParser->parse( $value )
+				);
+
+				// Add the original value for easier post-processing in a template
+				// as hidden parameter
+				$key = 'bibtex-author';
 			}
 
 			$parserParameterProcessor->addParameter(

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -7,6 +7,7 @@ use SMW\NamespaceExaminer;
 use SMW\ParameterProcessorFactory;
 use SCI\Bibtex\BibtexProcessor;
 use SCI\Bibtex\BibtexParser;
+use SCI\Bibtex\BibtexAuthorListParser;
 
 /**
  * @license GNU GPL v2+
@@ -51,7 +52,7 @@ class ParserFunctionFactory {
 				$namespaceExaminer,
 				$citationTextTemplateRenderer,
 				$mediaWikiNsContentMapper,
-				new BibtexProcessor( new BibtexParser() )
+				new BibtexProcessor( new BibtexParser(), new BibtexAuthorListParser() )
 			);
 
 			$sciteParserFunction->setStrictParserValidationState(

--- a/tests/phpunit/Integration/Parser/Fixtures/scite-13-bibtex-record-mapping.json
+++ b/tests/phpunit/Integration/Parser/Fixtures/scite-13-bibtex-record-mapping.json
@@ -26,7 +26,7 @@
 		{
 			"name": "Sci-property-definition",
 			"namespace": "NS_MEDIAWIKI",
-			"contents": "Some assignments\n type|Has reference type \n author|Has author \n authors|Has author \n title|Has title \n journal|Has publisher \n abstract|Has abstract\n"
+			"contents": "Some assignments\n type|Has reference type \n author|Has author \n title|Has title \n journal|Has publisher \n abstract|Has abstract\n"
 		},
 		{
 			"name": "Sci-template-definition",
@@ -39,16 +39,25 @@
 			"contents": "<includeonly>{{{title}}}</includeonly>"
 		},
 		{
+			"name": "SciteAuthorFormatter",
+			"namespace": "NS_TEMPLATE",
+			"contents": "<includeonly>{{{bibtex-author}}}</includeonly>"
+		},
+		{
 			"name": "Example/12/1",
 			"contents": "{{#scite:\n |bibtex=@ARTICLE{Meyer2000,\nAUTHOR=\"Bernd Meyer\",\nTITLE=\"A constraint-based framework for diagrammatic reasoning\",\nJOURNAL=\"Applied Artificial Intelligence\",\nVOLUME= \"14\",\nISSUE = \"4\",\nPAGES= \"327--344\",\nYEAR=2000\n}\n |citation text=2000}}"
 		},
 		{
 			"name": "Example/12/2",
-			"contents": "{{#scite:Einstein, Podolsky, and Nathan 1935\n |bibtex=@article{einstein1935can,\n  title={Can quantum-mechanical description of physical reality be considered complete?},\n  author={Einstein, Albert and Podolsky, Boris and Rosen, Nathan},\n  journal={Physical review},\n  volume={47},\n  number={10},\n  pages={777},\n  year={1935},\n  publisher={APS}\n}\n |authors=Albert Einstein, Boris Podolsky, Nathan Rosen|+sep=,\n}}"
+			"contents": "{{#scite:Einstein, Podolsky, and Nathan 1935\n |bibtex=@article{einstein1935can,\n  title={Can quantum-mechanical description of physical reality be considered complete?},\n  author={Einstein, Albert and Podolsky, Boris and Rosen, Nathan},\n  journal={Physical review},\n  volume={47},\n  number={10},\n  pages={777},\n  year={1935},\n  publisher={APS}\n}\n}}"
 		},
 		{
 			"name": "Example/12/3",
 			"contents": "{{#scite:|reference=Wallach and Kogan 1965b \n |type=book \n |bibtex=@article{wallach1965modes,\n  title={Modes of thinking in young children},\n  author={Wallach, Michael A and Kogan, Nathan},\n  year={1965},\n  publisher={New York}\n} \n}}"
+		},
+		{
+			"name": "Example/12/4",
+			"contents": "{{#scite:\n |bibtex=@article{leung1989vascular,\n  title={Vascular endothelial growth factor is a secreted angiogenic mitogen},\n  author={Leung, David W and Cachianes, George and Kuang, Wun-Jing and Goeddel, David V and Ferrara, Napoleone},\n  journal={Science},\n  volume={246},\n  number={4935},\n  pages={1306--1309},\n  year={1989},\n  publisher={American Association for the Advancement of Science}\n}\n |template=SciteAuthorFormatter}}"
 		}
 	],
 	"parser-testcases": [
@@ -97,6 +106,18 @@
 					"propertyCount": 6,
 					"propertyKeys": [ "__sci_cite_key", "__sci_cite_text", "Has_author", "Has_title", "Has_reference_type", "_SKEY" ],
 					"propertyValues": [ "book", "Wallach and Kogan 1965b", "Modes of thinking in young children" ]
+				}
+			}
+		},
+		{
+			"about": "#4 access hidden bibtex-author, see #12",
+			"subject": "Example/12/4#_SCITE-b375bde01f73d04037215f4614f81cc1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 7,
+					"propertyKeys": [ "__sci_cite_key", "__sci_cite_text", "Has_author", "Has_title", "Has_reference_type", "_SKEY", "Has_publisher" ],
+					"propertyValues": [ "Leung, David W and Cachianes, George and Kuang, Wun-Jing and Goeddel, David V and Ferrara, Napoleone", "David W Leung", "George Cachianes", "Wun-Jing Kuang", "David V Goeddel", "Napoleone Ferrara" ]
 				}
 			}
 		}

--- a/tests/phpunit/Unit/Bibtex/BibtexAuthorListParserTest.php
+++ b/tests/phpunit/Unit/Bibtex/BibtexAuthorListParserTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace SCI\Tests\Bibtex;
+
+use SCI\Bibtex\BibtexAuthorListParser;
+
+/**
+ * @covers \SCI\Bibtex\BibtexAuthorListParser
+ * @group semantic-cite
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class BibtexAuthorListParserTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SCI\Bibtex\BibtexAuthorListParser',
+			new BibtexAuthorListParser()
+		);
+	}
+
+	/**
+	 * @dataProvider authorListProvider
+	 */
+	public function testParse( $authorList, $expected ) {
+
+		$instance = new BibtexAuthorListParser();
+
+		$this->assertEquals(
+			$expected,
+			$instance->parse( $authorList )
+		);
+	}
+
+	public function authorListProvider() {
+
+		$provider = array();
+
+		// http://artis.imag.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html
+		$provider[] = array(
+			 'AA BB',
+			array(
+				'AA BB'
+			)
+		);
+
+		$provider[] = array(
+			 'AA',
+			array(
+				'AA'
+			)
+		);
+
+		$provider[] = array(
+			 'AA bb',
+			array(
+				'AA bb'
+			)
+		);
+
+		$provider[] = array(
+			 'AA bb CC',
+			array(
+				'AA bb CC'
+			)
+		);
+
+		$provider[] = array(
+			 'AA bb CC dd EE',
+			array(
+				'AA CC bb dd EE'
+			)
+		);
+
+		$provider[] = array(
+			 'AA 1B cc dd',
+			array(
+				'AA 1B cc dd'
+			)
+		);
+
+		$provider[] = array(
+			 'AA {b}B cc dd',
+			array(
+				'AA b'
+			)
+		);
+
+		$provider[] = array(
+			 'AA \BB{b} cc dd',
+			array(
+				'AA \BB b'
+			)
+		);
+
+		$provider[] = array(
+			 'bb CC dd EE, AA',
+			array(
+				'AA bb CC dd EE'
+			)
+		);
+
+		$provider[] = array(
+			 'bb CC,XX, AA',
+			array(
+				'AA bb CC XX'
+			)
+		);
+
+		$provider[] = array(
+			 'Einstein, Albert and Podolsky, Boris and Rosen, Nathan',
+			array(
+				'Albert Einstein',
+				'Boris Podolsky',
+				'Nathan Rosen'
+			)
+		);
+
+		$provider[] = array(
+			 'Leung, David W and Cachianes, George and Kuang, Wun-Jing and Goeddel, David V and Ferrara, Napoleone',
+			array(
+				'David W Leung',
+				'George Cachianes',
+				'Wun-Jing Kuang',
+				'David V Goeddel',
+				'Napoleone Ferrara'
+			)
+		);
+
+		$provider[] = array(
+			 'S. Zhang and C. Zhu and J. K. O. Sin and P. K. T. Mok',
+			array(
+				'S Zhang',
+				'C Zhu',
+				'J K O Sin',
+				'P K T Mok'
+			)
+		);
+
+		$provider[] = array(
+			 'R. M. A. Dawson and Z. Shen and D. A. Furst and
+                   S. Connor and J. Hsu and M. G. Kane and R. G. Stewart and
+                   A. Ipri and C. N. King and P. J. Green and R. T. Flegal
+                   and S. Pearson and W. A. Barrow and E. Dickey and K. Ping
+                   and C. W. Tang and S. Van. Slyke and
+                   F. Chen and J. Shi and J. C. Sturm and M. H. Lu',
+			array(
+				'R M A Dawson',
+				'Z Shen',
+				'D A Furst',
+				'S Connor',
+				'J Hsu',
+				'M G Kane',
+				'R G Stewart',
+				'A Ipri',
+				'C N King',
+				'P J Green',
+				'Flegal R T',
+				'S Pearson',
+				'W A Barrow',
+				'E Dickey',
+				'Ping K',
+				'C W Tang',
+				'Van. S Slyke',
+				'F Chen',
+				'J Shi',
+				'J C Sturm',
+				'M H Lu'
+			)
+		);
+
+		// van
+		$provider[] = array(
+			 'van den Bout, D. E.',
+			array(
+				'D E van den Bout'
+			)
+		);
+
+		// Jr.
+		$provider[] = array(
+			 'Osgood, Jr., R. M.',
+			array(
+				'R M Osgood Jr.'
+			)
+		);
+
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Bibtex/BibtexProcessorTest.php
+++ b/tests/phpunit/Unit/Bibtex/BibtexProcessorTest.php
@@ -21,9 +21,13 @@ class BibtexProcessorTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$bibtexAuthorListParser = $this->getMockBuilder( '\SCI\Bibtex\BibtexAuthorListParser' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->assertInstanceOf(
 			'\SCI\Bibtex\BibtexProcessor',
-			new BibtexProcessor( $bibtexParser )
+			new BibtexProcessor( $bibtexParser, $bibtexAuthorListParser )
 		);
 	}
 
@@ -36,6 +40,10 @@ class BibtexProcessorTest extends \PHPUnit_Framework_TestCase {
 		$bibtexParser->expects( $this->once() )
 			->method( 'parse' )
 			->will( $this->returnValue( array( 'Foo' => 'Bar' ) ) );
+
+		$bibtexAuthorListParser = $this->getMockBuilder( '\SCI\Bibtex\BibtexAuthorListParser' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$parserParameterProcessor = $this->getMockBuilder( '\SMW\ParserParameterProcessor' )
 			->disableOriginalConstructor()
@@ -52,7 +60,53 @@ class BibtexProcessorTest extends \PHPUnit_Framework_TestCase {
 				$this->equalTo( 'Foo' ),
 				$this->equalTo( 'Bar' ) );
 
-		$instance = new BibtexProcessor( $bibtexParser );
+		$instance = new BibtexProcessor( $bibtexParser, $bibtexAuthorListParser );
+
+		$instance->doProcess(
+			$parserParameterProcessor
+		);
+	}
+
+	public function testProcessAuthors() {
+
+		$bibtexParser = $this->getMockBuilder( '\SCI\Bibtex\BibtexParser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$bibtexParser->expects( $this->once() )
+			->method( 'parse' )
+			->will( $this->returnValue( array( 'author' => 'Foo' ) ) );
+
+		$bibtexAuthorListParser = $this->getMockBuilder( '\SCI\Bibtex\BibtexAuthorListParser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$bibtexAuthorListParser->expects( $this->once() )
+			->method( 'parse' )
+			->will( $this->returnValue( array( 'Foo' ) ) );
+
+		$parserParameterProcessor = $this->getMockBuilder( '\SMW\ParserParameterProcessor' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserParameterProcessor->expects( $this->once() )
+			->method( 'getParameterValuesFor' )
+			->with(	$this->equalTo( 'bibtex' ) )
+			->will( $this->returnValue( array( ) ) );
+
+		$parserParameterProcessor->expects( $this->once() )
+			->method( 'setParameter' )
+			->with(
+				$this->equalTo( 'author' ),
+				$this->equalTo( array( 'Foo' ) ) );
+
+		$parserParameterProcessor->expects( $this->once() )
+			->method( 'addParameter' )
+			->with(
+				$this->equalTo( 'bibtex-author' ),
+				$this->equalTo( 'Foo' ) );
+
+		$instance = new BibtexProcessor( $bibtexParser, $bibtexAuthorListParser );
 
 		$instance->doProcess(
 			$parserParameterProcessor
@@ -71,6 +125,10 @@ class BibtexProcessorTest extends \PHPUnit_Framework_TestCase {
 		$bibtexParser->expects( $this->once() )
 			->method( 'parse' )
 			->will( $this->returnValue( array( $parameter => 'Foo' ) ) );
+
+		$bibtexAuthorListParser = $this->getMockBuilder( '\SCI\Bibtex\BibtexAuthorListParser' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$parserParameterProcessor = $this->getMockBuilder( '\SMW\ParserParameterProcessor' )
 			->disableOriginalConstructor()
@@ -93,7 +151,7 @@ class BibtexProcessorTest extends \PHPUnit_Framework_TestCase {
 		$parserParameterProcessor->expects( $this->never() )
 			->method( 'addParameter' );
 
-		$instance = new BibtexProcessor( $bibtexParser );
+		$instance = new BibtexProcessor( $bibtexParser, $bibtexAuthorListParser );
 
 		$instance->doProcess(
 			$parserParameterProcessor


### PR DESCRIPTION
This allows for a string of authors ('Leung, David W and Cachianes, George and Kuang, Wun-Jing and Goeddel, David V and Ferrara, Napoleone') as in:

```
@article{leung1989vascular,
  title={Vascular endothelial growth factor is a secreted angiogenic mitogen},
  author={Leung, David W and Cachianes, George and Kuang, Wun-Jing and Goeddel, David V and Ferrara, Napoleone},
  journal={Science},
  volume={246},
  number={4935},
  pages={1306--1309},
  year={1989},
  publisher={American Association for the Advancement of Science}
}
```
to become an:
```
array(
	'David W Leung',
	'George Cachianes',
	'Wun-Jing Kuang',
	'David V Goeddel',
	'Napoleone Ferrara'
)
```
and with the help of the `ParserParameterProcessor` can be turned into something like:

```
{{#scite:
 |reference=leung1989va
 |type=journal-article
 |title=Vascular endothelial growth factor is a secreted angiogenic mitogen
 |author=David W Leung;George Cachianes;Wun-Jing Kuang;David V Goeddel;Napoleone Ferrara|+sep=;
```