### PR TITLE
Disable the auto-referencelist in NS_FILE

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Setup and configuration
+
+- SMW version:
+- MW version:
+- DB (MySQL etc.):
+
+### Issue
+
+Produces a [stack trace](https://www.semantic-mediawiki.org/wiki/Help:Identifying_bugs) and outputs:
+
+```
+```
+
+Steps to reproduce the observation (recommendation is to use the [sandbox](http://sandbox.semantic-mediawiki.org)):

--- a/docs/05-referencelist.md
+++ b/docs/05-referencelist.md
@@ -1,9 +1,9 @@
 ## #referencelist parser
 
-In general a reference list is auto-maintained and added to the bottom of a page if
-a citation reference is being detected. In case a use whishes to place a list differently,
-`#referencelist` can be used to mark the position on where the list is expected
-to appear.
+In general a reference list is auto-maintained (except for the NS_FILE namespace)
+and added to the bottom of a page if a citation reference is being detected. In
+case a user whishes to place a list differently, `#referencelist` can be used to
+mark the position as to where the list is expected to appear.
 
 Citation resources that use the same key are displayed on the reference list and
 linked to each other if `$GLOBALS['scigBrowseLinkToCitationResource']` is enabled.

--- a/src/CachedReferenceListOutputRenderer.php
+++ b/src/CachedReferenceListOutputRenderer.php
@@ -131,7 +131,9 @@ class CachedReferenceListOutputRenderer {
 			);
 		}
 
-		$text .= $this->getRenderedHtmlReferenceList();
+		if ( $this->contextInteractor->getTitle()->getNamespace() !== NS_FILE ) {
+			$text .= $this->getRenderedHtmlReferenceList();
+		}
 	}
 
 	private function getCustomizedRenderedHtmlReferenceList( $customOptions ) {

--- a/tests/phpunit/Unit/CachedReferenceListOutputRendererTest.php
+++ b/tests/phpunit/Unit/CachedReferenceListOutputRendererTest.php
@@ -111,4 +111,33 @@ class CachedReferenceListOutputRendererTest extends \PHPUnit_Framework_TestCase 
 		);
 	}
 
+	public function testNoAutoReferencelistOnFileNamespace() {
+
+		$this->contextInteractor->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( \Title::newFromText( __METHOD__, NS_FILE ) ) );
+
+		$this->contextInteractor->expects( $this->once() )
+			->method( 'hasAction' )
+			->will( $this->returnValue( true ) );
+
+		$this->contextInteractor->expects( $this->never() )
+			->method( 'getOldId' );
+
+		$this->namespaceExaminer->expects( $this->once() )
+			->method( 'isSemanticEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$instance =	new CachedReferenceListOutputRenderer(
+			$this->referenceListOutputRenderer,
+			$this->contextInteractor,
+			$this->namespaceExaminer,
+			$this->cache,
+			$this->cacheKeyProvider
+		);
+
+		$text = '';
+		$instance->addReferenceListToText( $text );
+	}
+
 }


### PR DESCRIPTION
Auto-referencelist in the NS_FILE can not be managed accurately, the outputpage
hook is running several times without a way to determine the position
hence a `{{#referencelist: ..}}` is expected to mark the position.