### PR TITLE
Update SemanticCite.php

### DIFF
--- a/SemanticCite.php
+++ b/SemanticCite.php
@@ -45,7 +45,7 @@ class SemanticCite {
 
 		// Register the extension
 		$GLOBALS['wgExtensionCredits']['semantic'][ ] = array(
-			'path'           => __DIR__,
+			'path'           => __FILE__,
 			'name'           => 'Semantic Cite',
 			'author'         => array( 'James Hong Kong' ),
 			'url'            => 'https://github.com/SemanticMediaWiki/SemanticCite/',


### PR DESCRIPTION
Allow the git hash and time stamp of the version to be shown on "Special:Version"

Refs issue https://github.com/SemanticMediaWiki/SemanticBreadcrumbLinks/issues/19