### PR TITLE
Changes pointer to reference container from Up Arrow to South East Arrow

### DIFF
--- a/src/CitationResourceMatchFinder.php
+++ b/src/CitationResourceMatchFinder.php
@@ -53,8 +53,8 @@ class CitationResourceMatchFinder {
 
 		$citationResourceLinks = [];
 
-		// ↑; $reference
-		$caption = $caption !== '' ? $caption : '&#8593;';
+		// ↘; $reference
+		$caption = $caption !== '' ? $caption : '&#8600;';
 
 		foreach ( $subjects as $subject ) {
 


### PR DESCRIPTION
* Changes pointer to reference container from Up Arrow to South East Arrow

Rationale: When I click on the arrow I instinctively expect to end up at the spot on the page using the reference whereas I always end up in the container. Compared to the Circumflex the arrow is just to dominant though I do not think that the size of the arrow should be changed from 130%. 