### PR TITLE
Set target reference

### DIFF
--- a/res/scite.styles.css
+++ b/res/scite.styles.css
@@ -79,8 +79,8 @@
 	word-wrap: break-word;
 }
 
-.scite-referencelist span:target {
-	background-color:#FFFBD0;
+.scite-referencelist span:target, .scite-referencelist li:target {
+	background-color: rgba( 0,127,255,0.133 );
 }
 
 .scite-referencelist span:target a {
@@ -93,6 +93,10 @@
 
 .scite-citation-resourcelink {
 	font-size: 130%;
+}
+
+.scite-citation-resourcelink a:before {
+	content: "↑";
 }
 
 .scite-citation-key {

--- a/src/CitationResourceMatchFinder.php
+++ b/src/CitationResourceMatchFinder.php
@@ -53,9 +53,6 @@ class CitationResourceMatchFinder {
 
 		$citationResourceLinks = [];
 
-		// ↑; $reference
-		$caption = $caption !== '' ? $caption : '&#8593;';
-
 		foreach ( $subjects as $subject ) {
 
 			$dataValue = $this->dataValueFactory->newDataItemValue(

--- a/tests/phpunit/Integration/JSONScript/TestCases/scite-01-simple-intext-reference.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/scite-01-simple-intext-reference.json
@@ -54,7 +54,7 @@
 			"expected-output": {
 				"to-contain": [
 					"<span id=\"scite-ref-86f84b9b2cf2ae4405199e26f121b4e9-1-a\" class=\"scite-citeref-number\" data-reference=\"Foo:123\"><a href=\"#scite-86f84b9b2cf2ae4405199e26f121b4e9\">1</a></span>",
-					"<span id=\"scite-86f84b9b2cf2ae4405199e26f121b4e9\" class=\"scite-referencelinks\"><a href=\"#scite-ref-86f84b9b2cf2ae4405199e26f121b4e9-1-a\" class=\"scite-backlink\" data-citeref-format=\"number\">^</a></span>"
+					"<li id=\"scite-86f84b9b2cf2ae4405199e26f121b4e9\"><span class=\"scite-referencelinks\"><a href=\"#scite-ref-86f84b9b2cf2ae4405199e26f121b4e9-1-a\" class=\"scite-backlink\" data-citeref-format=\"number\">^</a>"
 				]
 			}
 		},
@@ -72,7 +72,7 @@
 			"expected-output": {
 				"to-contain": [
 					"<span id=\"scite-ref-86f84b9b2cf2ae4405199e26f121b4e9-1-a\" class=\"scite-citeref-number\" data-reference=\"Foo:123\"><a href=\"#scite-86f84b9b2cf2ae4405199e26f121b4e9\">1</a></span><span class=\"scite-citeref-shortcaption\">:50-52</span>",
-					"<span id=\"scite-86f84b9b2cf2ae4405199e26f121b4e9\" class=\"scite-referencelinks\"><a href=\"#scite-ref-86f84b9b2cf2ae4405199e26f121b4e9-1-a\" class=\"scite-backlink\" data-citeref-format=\"number\">^</a></span>"
+					"<li id=\"scite-86f84b9b2cf2ae4405199e26f121b4e9\"><span class=\"scite-referencelinks\"><a href=\"#scite-ref-86f84b9b2cf2ae4405199e26f121b4e9-1-a\" class=\"scite-backlink\" data-citeref-format=\"number\">^</a>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/scite-05-different-referencelist-position.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/scite-05-different-referencelist-position.json
@@ -31,7 +31,7 @@
 				"to-contain": [
 					"<span id=\"scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-citeref-number\" data-reference=\"Foo:abc\"><a href=\"#scite-4a4b33932ef3b5972e9c4bccfff6e2fc\">1</a></span>",
 					"<div class=\"scite-content\">",
-					"<span id=\"scite-4a4b33932ef3b5972e9c4bccfff6e2fc\" class=\"scite-referencelinks\"><a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-backlink\" data-citeref-format=\"number\">^</a>",
+					"<li id=\"scite-4a4b33932ef3b5972e9c4bccfff6e2fc\"><span class=\"scite-referencelinks\"><a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-backlink\" data-citeref-format=\"number\">^</a>",
 					"<span class=\"scite-citation-text\">Citation for bar</span>"
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/scite-08-ul-referencelist-with-key.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/scite-08-ul-referencelist-with-key.json
@@ -31,7 +31,7 @@
 				"to-contain": [
 					"<span id=\"scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-citeref-key\" data-reference=\"Foo:abc\"><a href=\"#scite-4a4b33932ef3b5972e9c4bccfff6e2fc\">Foo:abc</a></span>",
 					"<div class=\"scite-content\">",
-					"<ul start=1><li><span id=\"scite-4a4b33932ef3b5972e9c4bccfff6e2fc\" class=\"scite-referencelinks\"><a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-backlink\" data-citeref-format=\"key\">^</a></span>",
+					"<ul start=1><li id=\"scite-4a4b33932ef3b5972e9c4bccfff6e2fc\"><span class=\"scite-referencelinks\"><a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-backlink\" data-citeref-format=\"key\">^</a>",
 					"<span class=\"scite-citation-text\">Citation for bar</span>"
 				]
 			}
@@ -52,7 +52,7 @@
 					"<span id=\"scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-citeref-key\" data-reference=\"Foo:abc\"><a href=\"#scite-4a4b33932ef3b5972e9c4bccfff6e2fc\">Foo:abc</a></span>",
 					"<span id=\"scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-b\" class=\"scite-citeref-key\" data-reference=\"Foo:abc\"><a href=\"#scite-4a4b33932ef3b5972e9c4bccfff6e2fc\">Foo:abc</a></span>",
 					"<div class=\"scite-content\">",
-					"<ul start=1><li>",
+					"<ul start=1><li id=\"scite-4a4b33932ef3b5972e9c4bccfff6e2fc\">",
 					"<a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-backlinks\" data-citeref-format=\"key\">a</a>",
 					"<a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-b\" class=\"scite-backlinks\" data-citeref-format=\"key\">b</a>",
 					"<span class=\"scite-citation-text\">Citation for bar</span>"

--- a/tests/phpunit/Integration/JSONScript/TestCases/scite-09-nonbound-referencelist.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/scite-09-nonbound-referencelist.json
@@ -37,7 +37,7 @@
 					"<a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-backlink\" data-citeref-format=\"key\">^</a>",
 					"<span class=\"scite-citation-text\">Citation for bar</span>",
 					"<div class=\"scite-content\"><h2 id=\"Notes\">Notes</h2>",
-					"<span id=\"scite-Bar:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span>"
+					"<li id=\"scite-Bar:abc\"><span class=\"scite-referencelinks\"></span><span class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span></span></li>"
 				]
 			}
 		},
@@ -58,7 +58,7 @@
 					"<a href=\"#scite-ref-4a4b33932ef3b5972e9c4bccfff6e2fc-1-a\" class=\"scite-backlink\" data-citeref-format=\"key\">^</a>",
 					"<span class=\"scite-citation-text\">Citation for bar</span>",
 					"<div class=\"scite-content\"><h2 id=\"Notes\">Notes</h2>",
-					"<span id=\"scite-Bar:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span>"
+					"<li id=\"scite-Bar:abc\"><span class=\"scite-referencelinks\"></span><span class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span></span></li>"
 				]
 			}
 		},
@@ -76,8 +76,8 @@
 			"expected-output": {
 				"to-contain": [
 					"<div class=\"scite-content\"><h2 id=\"Notes\">Notes</h2>",
-					"<span id=\"scite-Bar:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span>",
-					"<span id=\"scite-Foo:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for bar</span>"
+					"<li id=\"scite-Bar:abc\"><span class=\"scite-referencelinks\"></span><span class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span></span></li>",
+					"<li id=\"scite-Foo:abc\"><span class=\"scite-referencelinks\"></span><span class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for bar</span></span></li>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/scite-11-noreferencelist-magic-word.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/scite-11-noreferencelist-magic-word.json
@@ -22,8 +22,8 @@
 			"expected-output": {
 				"to-contain": [
 					"<div class=\"scite-content\"><h2 id=\"Notes\">Notes</h2>",
-					"<span id=\"scite-Bar:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span>",
-					"<span id=\"scite-Foo:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for bar</span>"
+					"<li id=\"scite-Bar:abc\"><span class=\"scite-referencelinks\"></span><span class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span></span></li>",
+					"<li id=\"scite-Foo:abc\"><span class=\"scite-referencelinks\"></span><span class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for bar</span></span></li>"
 				]
 			}
 		},
@@ -33,8 +33,8 @@
 			"expected-output": {
 				"to-not-contain": [
 					"<div class=\"scite-content\"><h2 id=\"Notes\">Notes</h2>",
-					"<span id=\"scite-Bar:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span>",
-					"<span id=\"scite-Foo:abc\" class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for bar</span>"
+					"<li id=\"scite-Bar:abc\"><span class=\"scite-referencelinks\"></span><span class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for a loose reference</span></span></li>",
+					"<li id=\"scite-Foo:abc\"><span class=\"scite-referencelinks\"></span><span class=\"scite-citation\"><span class=\"scite-citation-text\">Citation for bar</span></span></li>"
 				]
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: #56, https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3068

This PR addresses or contains:

- Highlights the target (only works with SMW 3.0+ because it requires https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3068)
- Use `.scite-citation-resourcelink a:before` to change the appearance of `Special:Browse` resource link which by default is `↑`

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

![image](https://user-images.githubusercontent.com/1245473/38167043-385e6bb6-351e-11e8-9e34-b1a4ec80f738.png)

Fixes: #56