### PR TITLE
Add extension.json support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     - env: DB=mysql; MW=REL1_29; TYPE=coverage; PHPUNIT=4.8.*
       php: 5.6
     - env: DB=mysql; MW=REL1_27;
-      php: 5.5
+      php: 5.6
     - env: DB=sqlite; MW=REL1_28; SITELANG=ja
       php: 5.6
     - env: DB=sqlite; MW=master; PHPUNIT=4.8.*
-      php: '7'
+      php: 7.1
   exclude:
     - env: THENEEDFORTHIS=FAIL
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticCite"
 	},
 	"require": {
-		"php": ">=5.5.0",
+		"php": ">=5.6.0",
 		"composer/installers": "^1.0.12",
 		"mediawiki/semantic-media-wiki": "~2.5|~3.0",
 		"onoi/cache": "~1.2",
@@ -44,7 +44,6 @@
 	},
 	"autoload": {
 		"files" : [
-			"DefaultSettings.php",
 			"SemanticCite.php"
 		],
 		"psr-4": {
@@ -55,6 +54,7 @@
 		"process-timeout": 0
 	},
 	"scripts":{
-		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist"
+		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
+		"test": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
 		"mediawiki",
     		"citation"
 	],
-	"homepage": "https://semantic-mediawiki.org/wiki/Extension:SemanticCite",
+	"homepage": "https://semantic-mediawiki.org/wiki/Extension:Semantic_Cite",
 	"license": "GPL-2.0-or-later",
 	"authors": [
 		{
-			"name": "mwjames",
+			"name": "James Hong Kong",
 			"role": "Developer"
 		}
 	],

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,25 @@
+{
+	"name": "SemanticCite",
+	"version": "2.0.0-alpha",
+	"author": [
+        "James Hong Kong"
+	],
+	"url": "https://github.com/SemanticMediaWiki/SemanticCite/",
+	"descriptionmsg": "sci-desc",
+	"license-name": "GPL-2.0+",
+	"type": "semantic",
+	"requires": {
+		"MediaWiki": ">= 1.27"
+	},
+	"MessagesDirs": {
+		"SemanticCite": [
+			"i18n"
+		]
+	},
+	"callback": "SemanticCite::initExtension",
+	"ExtensionFunctions": [
+		"SemanticCite::onExtensionFunction"
+	],
+	"load_composer_autoloader":true,
+	"manifest_version": 1
+}

--- a/extension.json
+++ b/extension.json
@@ -6,7 +6,7 @@
 	],
 	"url": "https://github.com/SemanticMediaWiki/SemanticCite/",
 	"descriptionmsg": "sci-desc",
-	"license-name": "GPL-2.0+",
+	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
 		"MediaWiki": ">= 1.27"

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -114,6 +114,42 @@ class HookRegistry {
 		);
 	}
 
+	/**
+	 * @since 2.0
+	 *
+	 * @param array &$vars
+	 */
+	public static function initExtension( &$vars ) {
+
+		$vars['wgHooks']['SMW::Config::BeforeCompletion'][] = function( &$config ) {
+
+			$exemptionlist = [
+				PropertyRegistry::SCI_CITE
+			];
+
+			// Exclude listed properties from indexing
+			if ( isset( $config['smwgFulltextSearchPropertyExemptionList'] ) ) {
+				$config['smwgFulltextSearchPropertyExemptionList'] = array_merge(
+					$config['smwgFulltextSearchPropertyExemptionList'],
+					$exemptionlist
+				);
+			}
+
+			// Exclude listed properties from dependency detection as each of the
+			// selected object would trigger an automatic change without the necessary
+			// human intervention and can therefore produce unwanted query updates
+
+			if ( isset( $config['smwgQueryDependencyPropertyExemptionList'] ) ) {
+				$config['smwgQueryDependencyPropertyExemptionList'] = array_merge(
+					$config['smwgQueryDependencyPropertyExemptionList'],
+					$exemptionlist
+				);
+			}
+
+			return true;
+		};
+	}
+
 	private function addCallbackHandlers( $store, $cache, $options ) {
 
 		$propertyRegistry = new PropertyRegistry();

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -84,21 +84,28 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->doTestRegisteredAfterDeleteSubjectComplete( $instance );
 	}
 
-	public function testOnBeforeConfigCompletion() {
+	public function testInitExtension() {
 
-		$config = [
-			'smwgFulltextSearchPropertyExemptionList' => []
-		];
+		$vars = [];
+		HookRegistry::initExtension( $vars );
 
 		$propertyExemptionList = [
 			'__sci_cite'
 		];
 
-		HookRegistry::onBeforeConfigCompletion( $config );
+		$config = [
+			'smwgFulltextSearchPropertyExemptionList' => [],
+			'smwgQueryDependencyPropertyExemptionList' => []
+		];
+
+		foreach ( $vars['wgHooks']['SMW::Config::BeforeCompletion'] as $callback ) {
+			call_user_func_array( $callback, [ &$config ] );
+		}
 
 		$this->assertEquals(
 			[
 				'smwgFulltextSearchPropertyExemptionList' => $propertyExemptionList,
+				'smwgQueryDependencyPropertyExemptionList' => $propertyExemptionList,
 			],
 			$config
 		);

--- a/tests/travis/install-semantic-cite.sh
+++ b/tests/travis/install-semantic-cite.sh
@@ -55,6 +55,7 @@ function updateConfiguration {
 
 	# SMW#1732
 	echo 'wfLoadExtension( "SemanticMediaWiki" );' >> LocalSettings.php
+	echo 'wfLoadExtension( "SemanticCite" );' >> LocalSettings.php
 
 	php maintenance/update.php --quick
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds support for `extension.json` hereby requires `wfLoadExtension( "SemanticCite" );` to be added to `LocalSettings.php` in order to enable the extension
- Change PHP min. requirement to PHP 5.6+

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
