### PR TITLE
Remove deprecated `mediawiki.api.parse` alias

### DIFF
--- a/SemanticCite.php
+++ b/SemanticCite.php
@@ -100,8 +100,7 @@ class SemanticCite {
 				'onoi.qtip',
 				'onoi.blobstore',
 				'onoi.util',
-				'ext.scite.styles',
-				'mediawiki.api.parse'
+				'ext.scite.styles'
 			],
 			'messages' => [
 				'sci-tooltip-citation-lookup-failure',


### PR DESCRIPTION
Refs: #70 

Deprecated `mediawiki.api.parse` alias will no longer present in MediaWiki 1.33 and later