### PR TITLE
Remove use of `getExtraneousFunctionFor` (SMW 3.1)

### DIFF
--- a/src/DataValues/CitationReferenceValue.php
+++ b/src/DataValues/CitationReferenceValue.php
@@ -62,7 +62,12 @@ class CitationReferenceValue extends StringValue {
 	 */
 	protected function parseUserValue( $value ) {
 
-		$this->citationReferencePositionJournal = $this->getExtraneousFunctionFor( '\SCI\CitationReferencePositionJournal' );
+		if ( method_exists( $this, 'getCallable' ) ) {
+			$citationReferencePositionJournal = $this->getCallable( 'sci.citationreferencepositionjournal' );
+			$this->citationReferencePositionJournal = $citationReferencePositionJournal();
+		} else {
+			$this->citationReferencePositionJournal = $this->getExtraneousFunctionFor( '\SCI\CitationReferencePositionJournal' );
+		}
 
 		$value = trim( $value );
 
@@ -103,7 +108,12 @@ class CitationReferenceValue extends StringValue {
 	public function getShortWikiText( $linked = null ) {
 
 		if ( $this->citationReferencePositionJournal === null ) {
-			$this->citationReferencePositionJournal = $this->getExtraneousFunctionFor( '\SCI\CitationReferencePositionJournal' );
+			if ( method_exists( $this, 'getCallable' ) ) {
+				$citationReferencePositionJournal = $this->getCallable( 'sci.citationreferencepositionjournal' );
+				$this->citationReferencePositionJournal = $citationReferencePositionJournal();
+			} else {
+				$this->citationReferencePositionJournal = $this->getExtraneousFunctionFor( '\SCI\CitationReferencePositionJournal' );
+			}
 		}
 
 		// We want the last entry here to get the major/minor

--- a/tests/phpunit/Unit/DataValues/CitationReferenceValueTest.php
+++ b/tests/phpunit/Unit/DataValues/CitationReferenceValueTest.php
@@ -48,15 +48,12 @@ class CitationReferenceValueTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->dataValueServiceFactory->importExtraneousFunctions(
-			[
-				'\SCI\CitationReferencePositionJournal' => function() use ( $citationReferencePositionJournal ) {
-					return $citationReferencePositionJournal;
-				}
-			]
-		);
+		$callback = function() use ( $citationReferencePositionJournal ) {
+			return $citationReferencePositionJournal;
+		};
 
 		$instance = new CitationReferenceValue();
+		$instance->addCallable( 'sci.citationreferencepositionjournal', $callback );
 
 		$instance->setDataValueServiceFactory(
 			$this->dataValueServiceFactory

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -139,6 +139,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$dataTypeRegistry = DataTypeRegistry::getInstance();
 
+		if ( method_exists( $dataTypeRegistry, 'clearCallables' ) ) {
+			 $dataTypeRegistry->clearCallables();
+		}
+
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $hook ),
 			[ $dataTypeRegistry ]
@@ -471,7 +475,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	private function assertThatHookIsExcutable( \Closure $handler, $arguments = [] ) {
+	private function assertThatHookIsExcutable( callable $handler, $arguments = [] ) {
 		$this->assertInternalType(
 			'boolean',
 			call_user_func_array( $handler, $arguments )


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3900

This PR addresses or contains:

- Removes use of `getExtraneousFunctionFor`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
