### PR TITLE
Avoid "Use of old calling convention for Parser::__construct was deprecated ..."

### DIFF
--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -23,9 +23,29 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() : void {
 		parent::setUp();
 
-		$this->parser = new Parser();
-		$this->parser->Options( new ParserOptions() );
-		$this->parser->clearState();
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parser = $this->getMockBuilder( '\Parser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parser->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$this->parser->expects( $this->any() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $parserOutput ) );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/PreTextFormatterTest.php
+++ b/tests/phpunit/Unit/PreTextFormatterTest.php
@@ -23,16 +23,6 @@ class PreTextFormatterTest extends \PHPUnit_Framework_TestCase {
 
 	const LF = "\n";
 
-	private $parser;
-
-	protected function setUp() : void {
-		parent::setUp();
-
-		$this->parser = new Parser();
-		$this->parser->Options( new ParserOptions() );
-		$this->parser->clearState();
-	}
-
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
