### PR TITLE
Replace usages of deprecated wfWikiID()

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Several short [videos](https://www.youtube.com/playlist?list=PLIJ9eX-UsA5eI_YFdn
 ## Requirements
 
 - PHP 7.0 or later
-- MediaWiki 1.31 or later
+- MediaWiki 1.35 or later
 - [Semantic MediaWiki][smw] 3.0 or later
 
 Semantic Cite **does not require** nor uses any part of extension [Cite][mw-cite] (or `<ref>` tags) as a means to declare

--- a/SemanticCite.php
+++ b/SemanticCite.php
@@ -146,7 +146,7 @@ class SemanticCite {
 
 		// Require a global because MW's Special page is missing an interface
 		// to inject dependencies
-		$GLOBALS['scigCachePrefix'] = $GLOBALS['wgCachePrefix'] === false ? wfWikiID() : $GLOBALS['wgCachePrefix'];
+		$GLOBALS['scigCachePrefix'] = $GLOBALS['wgCachePrefix'] === false ? WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
 
 		$configuration = [
 			'numberOfReferenceListColumns'       => $GLOBALS['scigNumberOfReferenceListColumns'],

--- a/extension.json
+++ b/extension.json
@@ -10,7 +10,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.31",
+		"MediaWiki": ">= 1.35",
 		"extensions": {
 			"SemanticMediaWiki": ">= 3.0"
 		}


### PR DESCRIPTION
The global function wfWikiID() is hard deprecated since 1.38, and its usages should be replaced with WikiMap::getCurrentWikiId().

This PR addresses or contains:
- https://phabricator.wikimedia.org/T298059

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed