### PR TITLE
Remove branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,6 @@
 	"require-dev": {
 		"mediawiki/semantic-media-wiki": "@dev"
 	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "2.x-dev"
-		}
-	},
 	"autoload": {
 		"files" : [
 			"SemanticCite.php"


### PR DESCRIPTION
One less thing to update, and AFAIK there is no use case that relies on this alias
