### PR TITLE
RELEASE-NOTES.md: Fix release date for version 3.0.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,7 +1,7 @@
 This file contains the RELEASE-NOTES of the **Semantic Cite** (a.k.a. SCI) extension.
 
 ## 3.0.0
-Released on November 28, 2023.
+Released on February 23, 2024.
 
 * Minimum requirement for
   * PHP changed to version 7.4 and later


### PR DESCRIPTION
In preparation of release, as we aren't in 2023 anymore + and I want to make date correct.

Made as a follow-up to #119, inspired by #126.