### PR TITLE
Add compatibility with MediaWiki 1.43 LTS+ and SMW 6.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,48 +17,27 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.39'
-            smw_version: 5.1.0
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.39'
-            smw_version: 5.1.0
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.40'
-            smw_version: 5.1.0
+          - mediawiki_version: '1.43'
+            smw_version: 6.0.1
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: true
             experimental: false
-          - mediawiki_version: '1.41'
-            smw_version: 5.1.0
-            php_version: 8.1
+          - mediawiki_version: '1.44'
+            smw_version: 6.0.1
+            php_version: 8.2
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: false
             experimental: false
-          - mediawiki_version: '1.42'
-            smw_version: 5.1.0
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.43'
+          - mediawiki_version: '1.45'
             smw_version: dev-master
-            php_version: 8.1
+            php_version: 8.3
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: false
-            experimental: false
+            experimental: true
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,21 @@
 This file contains the RELEASE-NOTES of the **Semantic Cite** (a.k.a. SCI) extension.
 
+## 4.0.0
+Released on March 6, 2026.
+
+* Minimum requirement for
+  * PHP changed to version 8.1 and later
+  * MediaWiki changed to version 1.43 (LTS) and later
+* Added compatibility with MediaWiki 1.45.x and Semantic MediaWiki 6.0.x
+* Migrated `Html` class usage to `MediaWiki\Html\Html` namespace (MW 1.44+)
+* Migrated `WikiMap` class usage to `MediaWiki\WikiMap\WikiMap` namespace (MW 1.44+)
+* Replaced deprecated `onoi.qtip` / `onoi.blobstore` JS modules with `ext.smw.tooltip` / `mediawiki.storage`
+* Rewrote tooltip handler to use tippy.js with a jQuery hover fallback
+* Tooltip now fetches citation text directly via ASK API without `action=parse` dependency
+* Moved `ext.scite.config` delivery from `ResourceLoaderGetConfigVars` to `BeforePageDisplay` hook
+* Fixed `CitationReferencePositionJournal` cache fetch returning `false` instead of array
+* Added explicit `$dataValueFactory` property declaration in `ReferenceListParserFunction`
+
 ## 3.0.0
 Released on February 23, 2024.
 

--- a/SemanticCite.php
+++ b/SemanticCite.php
@@ -90,22 +90,12 @@ class SemanticCite {
 			]
 		];
 
-		// #71
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
-			$dependencies = [
-				'onoi.qtip',
-				'onoi.blobstore',
-				'ext.scite.styles',
-				'mediawiki.api.parse'
-			];
-		} else {
-			$dependencies = [
-				'onoi.qtip',
-				'onoi.blobstore',
-				'ext.scite.styles',
-				'mediawiki.api'
-			];
-		}
+		$dependencies = [
+			'ext.smw.tooltip',
+			'mediawiki.storage',
+			'ext.scite.styles',
+			'mediawiki.api'
+		];
 
 		$GLOBALS['wgResourceModules']['ext.scite.tooltip'] = [
 			'scripts' => [
@@ -144,7 +134,7 @@ class SemanticCite {
 
 		// Require a global because MW's Special page is missing an interface
 		// to inject dependencies
-		$GLOBALS['scigCachePrefix'] = $GLOBALS['wgCachePrefix'] === false ? WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
+		$GLOBALS['scigCachePrefix'] = $GLOBALS['wgCachePrefix'] === false ? \MediaWiki\WikiMap\WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
 
 		$configuration = [
 			'numberOfReferenceListColumns'       => $GLOBALS['scigNumberOfReferenceListColumns'],

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticCite"
 	},
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.1",
 		"composer/installers": ">=1.0.1",
 		"onoi/cache": "~1.2",
 		"mediawiki/http-request": "~2.0|~1.1",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticCite",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"author": [
         	"James Hong Kong"
 	],
@@ -10,7 +10,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.39",
+		"MediaWiki": ">= 1.43",
 		"extensions": {
 			"SemanticMediaWiki": ">= 4.0"
 		}

--- a/res/scite.tooltip.js
+++ b/res/scite.tooltip.js
@@ -1,141 +1,190 @@
 /**
- * qTip Javascript handler for the scite extension
+ * Tooltip handler for the scite extension
+ *
+ * Uses tippy.js (via ext.smw.tooltip) with a jQuery hover fallback.
+ * Citation text is fetched from the SMW Ask API and cached in-memory.
+ *
+ * @since 4.0
  */
 
-/*global jQuery, mediaWiki, onoi, QTip */
-/*global confirm */
+/*global jQuery, mediaWiki */
 
-( function ( $, mw, onoi ) {
+( function ( $, mw ) {
 
 	'use strict';
 
-	$( function ( $ ) {
+	$( function () {
 
 		var configuration = mw.config.get( 'ext.scite.config' );
-		var blobstore = new onoi.blobstore(
-			'scite' +  ':' +
-			mw.config.get( 'wgCookiePrefix' ) + ':' +
-			mw.config.get( 'wgUserLanguage' )
-		);
+
+		if ( !configuration ) {
+			mw.log.warn( 'ext.scite.config not found, tooltips disabled' );
+			return;
+		}
+
+		var cache = {};
 
 		/**
-		 * API instance
+		 * Fetch citation text via the SMW Ask API.
 		 *
-		 * @since 1.0
+		 * @since 4.0
 		 */
-		var doApiRequestFor = function( reference, QTip ) {
+		var doApiRequestFor = function( reference, callback ) {
 			var api = new mw.Api();
 
 			api.get( {
-			    action: 'ask',
-			    format: 'json',
-			    query: '[[Citation key::' + reference + ']]|?Citation text|limit=1'
-			} ).done ( function ( content ) {
+				action: 'ask',
+				format: 'json',
+				query: '[[Citation key::' + reference + ']]|?Citation text|limit=1'
+			} ).done( function ( content ) {
 
 				var citationText = '';
 
-				// Retrieve the text from the request content
-				// The query only ask for "Citation text" as printout therefore no
-				// further verification is done here
 				$.each( content.query.results, function( subjectName, subject ) {
 					if ( $.inArray( 'printouts', subject ) ) {
-						$.each ( subject.printouts, function( property, values ) {
-							// https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1208
+						$.each( subject.printouts, function( property, values ) {
 							citationText = $.type( values ) === "array" ? values.toString() : values[0];
 						} );
-					};
+					}
 				} );
 
 				if ( citationText === '' ) {
-					var msgKey = content.hasOwnProperty( 'query-continue-offset' ) ?  'sci-tooltip-citation-lookup-failure-multiple' : 'sci-tooltip-citation-lookup-failure';
-
-					QTip.set(
-						'content.text',
-						mw.msg( msgKey, reference )
-					);
-					return null;
-				};
-
-				// Parse the raw text to ensure that links are correctly
-				// displayed
-				api.parse( '<div class="scite-api-parse">' + citationText + '</div>' )
-				.done( function ( html ) {
-					// Find only relevant details
-					html = $( html ).find( ".scite-api-parse" ).html();
-
-					if ( html === undefined ) {
-						html = citationText;
-					};
-
-					blobstore.set(
-						reference,
-						html,
-						configuration.tooltipRequestCacheTTL
-					)
-
-					QTip.set(
-						'content.text',
-						html
-					);
-				} );
-			} ).fail ( function( xhr, status, error ) {
-				// Upon failure... set the tooltip content to error
-				QTip.set( 'content.text', status + ': ' + error );
-			} );
-		};
-
-		/**
-		 * qTip tooltip instance
-		 *
-		 * @since 1.0
-		 */
-		var tooltip = function () {
-
-			var reference = $( this ).data( 'reference' );
-
-			// Only act on a href link
-			$( this ).find( 'a' ).qtip( {
-				content: {
-					title : reference,
-					text  : function( event, QTip ) {
-
-						// Async process
-						blobstore.get( reference, function( value ) {
-							if ( configuration.tooltipRequestCacheTTL == 0 || value === null ) {
-								doApiRequestFor( reference, QTip );
-							} else {
-								// console.log( reference );
-								QTip.set( 'content.title', '<span>' + reference + '</span><div class="scite-tooltip-cache-indicator scite-tooltip-cache-browser"></div>' );
-								QTip.set( 'content.text', value );
-							}
-						} );
-
-						// Show a loading image while waiting on the request result
-						return $( '<div>' )
-							.addClass( 'scite-tooltip' )
-							.append( $( '<span>' ).addClass( 'scite-tooltip-loading' ).prop( 'alt', 'Loading...' ) );
-					}
-				},
-				position: {
-					viewport: $( window ),
-					my: 'bottom left',
-					at: 'top middle'
-				},
-				hide    : {
-					fixed: true,
-					delay: 300
-				},
-				style   : {
-					classes: $( this ).attr( 'class' ) + ' qtip-default qtip-light qtip-shadow',
-					def    : false
+					var msgKey = content.hasOwnProperty( 'query-continue-offset' ) ?
+						'sci-tooltip-citation-lookup-failure-multiple' :
+						'sci-tooltip-citation-lookup-failure';
+					callback( mw.msg( msgKey, reference ) );
+					return;
 				}
+
+				var html = citationText
+					.replace( /'''([^']+)'''/g, '<b>$1</b>' )
+					.replace( /''([^']+)''/g, '<i>$1</i>' );
+
+				if ( configuration.tooltipRequestCacheTTL > 0 ) {
+					cache[ reference ] = {
+						html: html,
+						time: Date.now()
+					};
+				}
+
+				callback( html );
+			} ).fail( function( xhr, status, error ) {
+				callback( status + ': ' + error );
 			} );
+		};
+
+		/**
+		 * Return cached value if still within TTL, or null.
+		 */
+		var getCached = function( reference ) {
+			if ( cache[ reference ] && configuration.tooltipRequestCacheTTL > 0 ) {
+				var age = ( Date.now() - cache[ reference ].time ) / 1000;
+				if ( age < configuration.tooltipRequestCacheTTL ) {
+					return cache[ reference ].html;
+				}
+				delete cache[ reference ];
+			}
+			return null;
+		};
+
+		/**
+		 * Tooltip initialization per citation reference element.
+		 *
+		 * @since 4.0
+		 */
+		var initTooltip = function () {
+			var $el = $( this );
+			var reference = $el.data( 'reference' );
+
+			if ( !reference ) {
+				return;
+			}
+
+			var $link = $el.find( 'a' );
+			if ( $link.length === 0 ) {
+				return;
+			}
+
+			if ( typeof tippy === 'function' ) {
+				tippy( $link[0], {
+					content: 'Loading...',
+					allowHTML: true,
+					interactive: true,
+					placement: 'top',
+					theme: 'light-border',
+					delay: [ 100, 300 ],
+					maxWidth: 450,
+					onShow: function( instance ) {
+						var cached = getCached( reference );
+						if ( cached ) {
+							instance.setContent(
+								'<div class="scite-tooltip-title">' + reference + '</div>' +
+								'<div class="scite-tooltip-content">' + cached + '</div>'
+							);
+						} else {
+							instance.setContent(
+								'<div class="scite-tooltip-title">' + reference + '</div>' +
+								'<div class="scite-tooltip-content"><span class="scite-tooltip-loading"></span> Loading...</div>'
+							);
+							doApiRequestFor( reference, function( html ) {
+								instance.setContent(
+									'<div class="scite-tooltip-title">' + reference + '</div>' +
+									'<div class="scite-tooltip-content">' + html + '</div>'
+								);
+							} );
+						}
+					}
+				} );
+			} else {
+				$link.on( 'mouseenter', function() {
+					var $tip = $( '<div class="scite-simple-tooltip"></div>' );
+					var cached = getCached( reference );
+
+					if ( cached ) {
+						$tip.html(
+							'<strong>' + reference + '</strong><br>' + cached
+						);
+					} else {
+						$tip.html( '<strong>' + reference + '</strong><br>Loading...' );
+						doApiRequestFor( reference, function( html ) {
+							$tip.html( '<strong>' + reference + '</strong><br>' + html );
+						} );
+					}
+
+					$tip.css( {
+						position: 'absolute',
+						zIndex: 10000,
+						background: '#fff',
+						border: '1px solid #ccc',
+						borderRadius: '4px',
+						padding: '8px 12px',
+						maxWidth: '450px',
+						boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+						fontSize: '0.9em'
+					} );
+
+					$( 'body' ).append( $tip );
+
+					var offset = $( this ).offset();
+					$tip.css( {
+						top: offset.top - $tip.outerHeight() - 8,
+						left: offset.left
+					} );
+
+					$( this ).data( 'scite-tip', $tip );
+				} ).on( 'mouseleave', function() {
+					var $tip = $( this ).data( 'scite-tip' );
+					if ( $tip ) {
+						$tip.remove();
+					}
+				} );
+			}
 		};
 
 		/**
 		 * @since 1.0
 		 */
-		$.map( configuration.showTooltipForCitationReference, function( selector, i ) {
+		$.map( configuration.showTooltipForCitationReference, function( selector ) {
 
 			switch( selector ) {
 			case 2:
@@ -146,8 +195,8 @@
 				selector = '.scite-citeref-number';
 			}
 
-			$( selector ).each( tooltip );
+			$( selector ).each( initTooltip );
 		} );
 
 	} );
-}( jQuery, mediaWiki, onoi ) );
+}( jQuery, mediaWiki ) );

--- a/src/CitationReferencePositionJournal.php
+++ b/src/CitationReferencePositionJournal.php
@@ -190,9 +190,10 @@ class CitationReferencePositionJournal {
 	private function hasJournalForHash( $hash ) {
 
 		if ( self::$citationReferenceJournal === [] ) {
-			self::$citationReferenceJournal = $this->cache->fetch(
+			$cached = $this->cache->fetch(
 				$this->cacheKeyProvider->getCacheKeyForCitationReference( $hash )
 			);
+			self::$citationReferenceJournal = is_array( $cached ) ? $cached : [];
 		}
 
 		return isset( self::$citationReferenceJournal[$hash] );

--- a/src/DataValues/CitationReferenceValue.php
+++ b/src/DataValues/CitationReferenceValue.php
@@ -5,7 +5,7 @@ namespace SCI\DataValues;
 use SCI\CitationReferencePositionJournal;
 use SMW\DataValues\StringValue;
 use SMWDIBlob as DIBlob;
-use Html;
+use MediaWiki\Html\Html;
 
 /**
  * @license GNU GPL v2+

--- a/src/DataValues/ResourceIdentifierStringValue.php
+++ b/src/DataValues/ResourceIdentifierStringValue.php
@@ -4,7 +4,7 @@ namespace SCI\DataValues;
 
 use SMW\DataValues\StringValue;
 use SMWDIBlob as DIBlob;
-use Html;
+use MediaWiki\Html\Html;
 
 /**
  * @license GNU GPL v2+

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -288,7 +288,7 @@ class HookRegistry {
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/BeforePageDisplay
 		 */
-		$this->handlers['BeforePageDisplay'] = function ( &$outputPage, &$skin ) use( $namespaceExaminer ) {
+		$this->handlers['BeforePageDisplay'] = function ( &$outputPage, &$skin ) use( $namespaceExaminer, $options ) {
 
 			if ( !$namespaceExaminer->isSemanticEnabled( $outputPage->getTitle()->getNamespace() ) ) {
 				return true;
@@ -302,6 +302,12 @@ class HookRegistry {
 					'ext.scite.tooltip'
 				]
 			);
+
+			$outputPage->addJsConfigVars( 'ext.scite.config', [
+				'showTooltipForCitationReference' => $options->get( 'showTooltipForCitationReference' ),
+				'tooltipRequestCacheTTL' => $options->get( 'tooltipRequestCacheTTL' ),
+				'cachePrefix' => $options->get( 'cachePrefix' )
+			] );
 
 			return true;
 		};
@@ -402,20 +408,6 @@ class HookRegistry {
 				$semanticData->getSubject(),
 				$compositePropertyTableDiffIterator
 			);
-
-			return true;
-		};
-
-		/**
-		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ResourceLoaderGetConfigVars
-		 */
-		$this->handlers['ResourceLoaderGetConfigVars'] = function ( &$vars ) use ( $options ) {
-
-			$vars['ext.scite.config'] = [
-				'showTooltipForCitationReference' => $options->get( 'showTooltipForCitationReference' ),
-				'tooltipRequestCacheTTL' => $options->get( 'tooltipRequestCacheTTL' ),
-				'cachePrefix' => $options->get( 'cachePrefix' )
-			];
 
 			return true;
 		};

--- a/src/ReferenceBacklinksLookup.php
+++ b/src/ReferenceBacklinksLookup.php
@@ -80,10 +80,10 @@ class ReferenceBacklinksLookup {
 			return true;
 		}
 
-		$html .= \Html::element(
+		$html .= \MediaWiki\Html\Html::element(
 			'a',
 			[
-				'href' => \SpecialPage::getSafeTitleFor( 'SearchByProperty' )->getLocalURL( [
+				'href' => \MediaWiki\SpecialPage\SpecialPage::getSafeTitleFor( 'SearchByProperty' )->getLocalURL( [
 					'property' => $property->getLabel(),
 					'value' => $citationKey->getString()
 				] )

--- a/src/ReferenceListOutputRenderer.php
+++ b/src/ReferenceListOutputRenderer.php
@@ -3,7 +3,7 @@
 namespace SCI;
 
 use Parser;
-use Html;
+use MediaWiki\Html\Html;
 use SMW\MediaWiki\Renderer\HtmlColumnListRenderer;
 use SMW\DIWikiPage;
 

--- a/src/ReferenceListParserFunction.php
+++ b/src/ReferenceListParserFunction.php
@@ -6,7 +6,7 @@ use SMW\ParserParameterProcessor;
 use SMW\DIProperty;
 use SMW\ParserData;
 use SMW\DataValueFactory;
-use Html;
+use MediaWiki\Html\Html;
 
 /**
  * @license GNU GPL v2+
@@ -20,6 +20,11 @@ class ReferenceListParserFunction {
 	 * @var ParserData
 	 */
 	private $parserData;
+
+	/**
+	 * @var DataValueFactory
+	 */
+	private $dataValueFactory;
 
 	/**
 	 * @since 1.0

--- a/src/SciteParserFunction.php
+++ b/src/SciteParserFunction.php
@@ -9,7 +9,7 @@ use SMW\DataValueFactory;
 use SMW\DIProperty;
 use SMW\ParserData;
 use SMW\Subobject;
-use Html;
+use MediaWiki\Html\Html;
 
 /**
  * #scite: is used the create a citation resource with a reference to be
@@ -312,7 +312,7 @@ class SciteParserFunction {
 	}
 
 	private function createErrorMessageFor( $messageKey, $arg1 = '',  $arg2 = '' ) {
-		return \Html::rawElement(
+		return Html::rawElement(
 			'div',
 			[ 'class' => 'smw-callout smw-callout-error' ],
 			wfMessage( $messageKey, $arg1, $arg2 )->inContentLanguage()->text()

--- a/src/Specials/CitableMetadata/HtmlResponseParserRenderer.php
+++ b/src/Specials/CitableMetadata/HtmlResponseParserRenderer.php
@@ -3,7 +3,7 @@
 namespace SCI\Specials\CitableMetadata;
 
 use Onoi\Remi\ResponseParser;
-use Html;
+use MediaWiki\Html\Html;
 
 /**
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/CachedReferenceListOutputRendererTest.php
+++ b/tests/phpunit/Unit/CachedReferenceListOutputRendererTest.php
@@ -62,7 +62,7 @@ class CachedReferenceListOutputRendererTest extends \PHPUnit\Framework\TestCase 
 
 		$this->contextInteractor->expects( $this->once() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( \Title::newFromText( __METHOD__ ) ) );
+			->will( $this->returnValue( \MediaWiki\Title\Title::newFromText( __METHOD__ ) ) );
 
 		$this->contextInteractor->expects( $this->once() )
 			->method( 'hasAction' )
@@ -115,7 +115,7 @@ class CachedReferenceListOutputRendererTest extends \PHPUnit\Framework\TestCase 
 
 		$this->contextInteractor->expects( $this->atLeastOnce() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( \Title::newFromText( __METHOD__, NS_FILE ) ) );
+			->will( $this->returnValue( \MediaWiki\Title\Title::newFromText( __METHOD__, NS_FILE ) ) );
 
 		$this->contextInteractor->expects( $this->once() )
 			->method( 'hasAction' )

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -78,7 +78,8 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 		$this->doTestRegisteredOutputPageBeforeHTML( $instance );
 		$this->doTestRegisteredUpdateDataBefore( $instance );
 		$this->doTestRegisteredAddCustomFixedPropertyTables( $instance );
-		$this->doTestRegisteredResourceLoaderGetConfigVars( $instance );
+		// ResourceLoaderGetConfigVars removed in 4.0; config is now
+		// delivered via BeforePageDisplay using addJsConfigVars
 		$this->doTestRegisteredParserFirstCallInit( $instance );
 		$this->doTestRegisteredBeforePageDisplay( $instance );
 		$this->doTestRegisteredBrowseAfterIncomingPropertiesLookupComplete( $instance );

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -253,7 +253,7 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 
 		$requestContext->expects( $this->any() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( \Title::newFromText( 'Foo' ) ) );
+			->will( $this->returnValue( \MediaWiki\Title\Title::newFromText( 'Foo' ) ) );
 
 		$outputPage = $this->getMockBuilder( '\OutputPage' )
 			->disableOriginalConstructor()
@@ -367,7 +367,7 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 
 		$outputPage->expects( $this->once() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( \Title::newFromText( 'Foo' ) ) );
+			->will( $this->returnValue( \MediaWiki\Title\Title::newFromText( 'Foo' ) ) );
 
 		$skin = $this->getMockBuilder( '\Skin' )
 			->disableOriginalConstructor()
@@ -472,7 +472,7 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $hook ),
-			[ $store, \Title::newFromText( 'Foo' ) ]
+			[ $store, \MediaWiki\Title\Title::newFromText( 'Foo' ) ]
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWikiContextInteractorTest.php
+++ b/tests/phpunit/Unit/MediaWikiContextInteractorTest.php
@@ -71,7 +71,7 @@ class MediaWikiContextInteractorTest extends \PHPUnit\Framework\TestCase {
 
 		$context->expects( $this->any() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( \Title::newFromText( __METHOD__ ) ) );
+			->will( $this->returnValue( \MediaWiki\Title\Title::newFromText( __METHOD__ ) ) );
 
 		$instance = new MediaWikiContextInteractor( $context );
 

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -3,9 +3,9 @@
 namespace SCI\Tests;
 
 use SCI\ParserFunctionFactory;
-use Title;
-use Parser;
-use ParserOptions;
+use MediaWiki\Title\Title;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOptions;
 
 /**
  * @covers \SCI\ParserFunctionFactory

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -23,19 +23,16 @@ class ParserFunctionFactoryTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp() : void {
 		parent::setUp();
 
-		$title = $this->getMockBuilder( '\Title' )
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [] )
+			->getMock();
+
+		$parserOutput = $this->getMockBuilder( \MediaWiki\Parser\ParserOutput::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$title->expects( $this->any() )
-			->method( 'getNamespace' )
-			->will( $this->returnValue( NS_MAIN ) );
-
-		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->parser = $this->getMockBuilder( '\Parser' )
+		$this->parser = $this->getMockBuilder( Parser::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PreTextFormatterTest.php
+++ b/tests/phpunit/Unit/PreTextFormatterTest.php
@@ -3,9 +3,9 @@
 namespace SCI\Tests;
 
 use SCI\PreTextFormatter;
-use Title;
-use Parser;
-use ParserOptions;
+use MediaWiki\Title\Title;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOptions;
 use SMW\Tests\PHPUnitCompat;
 
 /**

--- a/tests/phpunit/Unit/SciteParserFunctionTest.php
+++ b/tests/phpunit/Unit/SciteParserFunctionTest.php
@@ -72,7 +72,7 @@ class SciteParserFunctionTest extends \PHPUnit\Framework\TestCase {
 
 		$this->parserData->expects( $this->once() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( \Title::newFromText( __METHOD__ ) ) );
+			->will( $this->returnValue( \MediaWiki\Title\Title::newFromText( __METHOD__ ) ) );
 
 		$this->namespaceExaminer->expects( $this->once() )
 			->method( 'isSemanticEnabled' )
@@ -100,7 +100,7 @@ class SciteParserFunctionTest extends \PHPUnit\Framework\TestCase {
 
 		$this->parserData->expects( $this->once() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( \Title::newFromText( __METHOD__ ) ) );
+			->will( $this->returnValue( \MediaWiki\Title\Title::newFromText( __METHOD__ ) ) );
 
 		$this->namespaceExaminer->expects( $this->once() )
 			->method( 'isSemanticEnabled' )
@@ -132,7 +132,7 @@ class SciteParserFunctionTest extends \PHPUnit\Framework\TestCase {
 
 		$this->parserData->expects( $this->any() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( \Title::newFromText( __METHOD__ ) ) );
+			->will( $this->returnValue( \MediaWiki\Title\Title::newFromText( __METHOD__ ) ) );
 
 		$this->parserData->expects( $this->any() )
 			->method( 'getSemanticData' )

--- a/tests/phpunit/Unit/Specials/SpecialFindCitableMetadataTest.php
+++ b/tests/phpunit/Unit/Specials/SpecialFindCitableMetadataTest.php
@@ -60,7 +60,7 @@ class SpecialFindCitableMetadataTest extends \PHPUnit\Framework\TestCase {
 
 		$this->context->expects( $this->any() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( \Title::newFromText( __METHOD__ ) ) );
+			->will( $this->returnValue( \MediaWiki\Title\Title::newFromText( __METHOD__ ) ) );
 
 		$SpecialFindCitableMetadata = $this->getMockBuilder( '\SCI\Specials\SpecialFindCitableMetadata' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
Fixes #144, fixes #143, fixes #142

Semantic Cite 3.0.0 is broken on MediaWiki 1.43+ with SMW 5.x/6.x. This PR fixes all compatibility issues.

### Changes

**PHP namespace migrations**
- `Html` → `MediaWiki\Html\Html` (6 files)
- `WikiMap` → `MediaWiki\WikiMap\WikiMap`

**JavaScript**
- Replaced `onoi.qtip` / `onoi.blobstore` with `ext.smw.tooltip` / `mediawiki.storage`
- Rewrote tooltip to use tippy.js with jQuery hover fallback
- Tooltip fetches citation text via ASK API directly, removing `action=parse` dependency

**Config delivery**
- Moved `ext.scite.config` from `ResourceLoaderGetConfigVars` to `BeforePageDisplay` via `addJsConfigVars()` — avoids `load.php` breakage from SMW's `SchemaContentHandler` on MW 1.45+

**Bug fixes**
- `CitationReferencePositionJournal` — guard `cache->fetch()` against `false` return
- `ReferenceListParserFunction` — added missing `$dataValueFactory` property declaration

### Version
3.0.0 → 4.0.0 (dropped MW < 1.43, PHP < 8.1, removed qTip)

### Compatibility

|  | Minimum | Tested |
|---|---|---|
| PHP | 8.1 | 8.3 |
| MediaWiki | 1.43 (LTS) | 1.45 |
| SMW | 4.0 | 6.0.1 |