### PR TITLE
Remove onoi/cache, onoi/remi and mediawiki/http-request dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,4 +160,3 @@ but can also be executed using `composer phpunit` from the extension base direct
 [docs-scite]: https://github.com/SemanticMediaWiki/SemanticCite/blob/master/docs/04-scite.md
 [docs-intext]: https://github.com/SemanticMediaWiki/SemanticCite/blob/master/docs/06-references.md
 [docs-referencelist]: https://github.com/SemanticMediaWiki/SemanticCite/blob/master/docs/05-referencelist.md
-[remi]: https://github.com/onoi/remi

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,8 +7,16 @@ MediaWiki major release it supports; versions 5.x and 6.x were skipped.
 
 * Minimum requirement for Semantic MediaWiki changed to version 7.0 and later
 * Added compatibility with Semantic MediaWiki 7.0.x
-* Replaced the removed `CacheFactory::newMediaWikiCompositeCache()` call with a
-  composite cache assembled directly from the `onoi/cache` library
+* Replaced the removed `CacheFactory::newMediaWikiCompositeCache()` call with
+  MediaWiki's `CachedBagOStuff`
+* Removed the `onoi/cache`, `onoi/remi` and `mediawiki/http-request`
+  dependencies in favour of MediaWiki built-ins; caching now uses
+  `BagOStuff`/`CachedBagOStuff` and metadata requests use `HttpRequestFactory`.
+  The bibliographic metadata parsers previously provided by `onoi/remi` are now
+  bundled under `SCI\FilteredMetadata`
+* Metadata-provider HTTP requests now verify TLS certificates; the bundled
+  parsers no longer skip peer verification (the former `onoi/remi` parsers
+  disabled it for some providers)
 * Replaced the removed `EntityIdManager::getDataItemPoolHashListFor()` call with
   `getDataItemsFromList()`
 * Replaced the removed `HtmlFormRenderer::getMessageBuilder()` usage with

--- a/SemanticCite.php
+++ b/SemanticCite.php
@@ -1,11 +1,11 @@
 <?php
 
 use MediaWiki\MediaWikiServices;
-use Onoi\Cache\Cache;
-use Onoi\Cache\CacheFactory as OnoiCacheFactory;
 use SCI\HookRegistry;
 use SCI\Options;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use Wikimedia\ObjectCache\BagOStuff;
+use Wikimedia\ObjectCache\CachedBagOStuff;
 
 /**
  * @see https://github.com/SemanticMediaWiki/SemanticCite/
@@ -165,28 +165,26 @@ class SemanticCite {
 	}
 
 	/**
-	 * Builds a composite cache (a fixed in-memory layer over a MediaWiki
-	 * object cache) using the `onoi/cache` library directly.
+	 * Builds an object cache that wraps a MediaWiki backend object cache with an
+	 * in-process layer (a fixed-size hash cache) so that repeated lookups within
+	 * the same request avoid hitting the backend.
 	 *
-	 * Semantic MediaWiki 7.0 removed `CacheFactory::newMediaWikiCompositeCache()`
-	 * along with its bundled copy of `onoi/cache`; Semantic Cite still depends on
-	 * `onoi/cache` directly, so the composite cache is assembled here.
+	 * This replaces the former `onoi/cache` composite cache; `CachedBagOStuff`
+	 * provides the equivalent in-memory-over-persistent behaviour using only
+	 * MediaWiki built-ins.
 	 *
 	 * @since 7.0
 	 *
 	 * @param int|string $cacheType
+	 *
+	 * @return BagOStuff
 	 */
-	public static function newCompositeCache( $cacheType ): Cache {
-		$cacheFactory = new OnoiCacheFactory();
-
+	public static function newCompositeCache( $cacheType ): BagOStuff {
 		$bagOStuff = MediaWikiServices::getInstance()->getObjectCacheFactory()->getInstance(
 			$cacheType
 		);
 
-		return $cacheFactory->newCompositeCache( [
-			$cacheFactory->newFixedInMemoryLruCache( 500 ),
-			$cacheFactory->newMediaWikiCache( $bagOStuff )
-		] );
+		return new CachedBagOStuff( $bagOStuff, [ 'maxKeys' => 500 ] );
 	}
 
 }

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,7 @@
 	},
 	"require": {
 		"php": ">=8.1",
-		"composer/installers": ">=1.0.1",
-		"onoi/cache": "~1.2",
-		"mediawiki/http-request": "~2.0|~1.1",
-		"onoi/remi":"~0.2"
+		"composer/installers": ">=1.0.1"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "43.0.0",

--- a/docs/09-notes.md
+++ b/docs/09-notes.md
@@ -40,4 +40,8 @@ placeholder is later replaced by `CachedReferenceListOutputRenderer::addReferenc
 
 ## Metadata search / provider
 
-Metadata selection and REST response parsing are provided by the `onoi/remi` library.
+Metadata selection and REST response parsing are handled by the bibliographic
+response parsers under `SCI\FilteredMetadata` (originally derived from the
+`onoi/remi` library and now bundled with the extension). HTTP requests are issued
+through MediaWiki's `HttpRequestFactory`, with successful responses cached in a
+MediaWiki object cache.

--- a/src/CachedReferenceListOutputRenderer.php
+++ b/src/CachedReferenceListOutputRenderer.php
@@ -2,9 +2,9 @@
 
 namespace SCI;
 
-use Onoi\Cache\Cache;
 use SMW\DataItems\WikiPage;
 use SMW\NamespaceExaminer;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -30,7 +30,7 @@ class CachedReferenceListOutputRenderer {
 	private $namespaceExaminer;
 
 	/**
-	 * @var Cache
+	 * @var BagOStuff
 	 */
 	private $cache;
 
@@ -55,10 +55,10 @@ class CachedReferenceListOutputRenderer {
 	 * @param ReferenceListOutputRenderer $referenceListOutputRenderer
 	 * @param MediaWikiContextInteractor $contextInteractor
 	 * @param NamespaceExaminer $namespaceExaminer
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 * @param CacheKeyProvider $cacheKeyProvider
 	 */
-	public function __construct( ReferenceListOutputRenderer $referenceListOutputRenderer, MediaWikiContextInteractor $contextInteractor, NamespaceExaminer $namespaceExaminer, Cache $cache, CacheKeyProvider $cacheKeyProvider ) {
+	public function __construct( ReferenceListOutputRenderer $referenceListOutputRenderer, MediaWikiContextInteractor $contextInteractor, NamespaceExaminer $namespaceExaminer, BagOStuff $cache, CacheKeyProvider $cacheKeyProvider ) {
 		$this->referenceListOutputRenderer = $referenceListOutputRenderer;
 		$this->contextInteractor = $contextInteractor;
 		$this->namespaceExaminer = $namespaceExaminer;
@@ -222,15 +222,17 @@ class CachedReferenceListOutputRenderer {
 		// Create an individual hash for when loose references are used
 		$renderedReferenceListHash = md5( $this->getSubject()->getHash() . $references . $fingerprint );
 
-		if ( $this->cache->contains( $key ) ) {
-			$container = $this->cache->fetch( $key );
+		$container = $this->cache->get( $key );
 
+		if ( is_array( $container ) ) {
 			// Match against revision, languageCode, and hash
 			if ( isset( $container['revId'] ) &&
 				$container['revId'] == $revId &&
 				isset( $container['text'][$lang][$renderedReferenceListHash] ) ) {
 				return $container['text'][$lang][$renderedReferenceListHash];
 			}
+		} else {
+			$container = [];
 		}
 
 		$renderedReferenceList = $this->referenceListOutputRenderer->doRenderReferenceListFor(
@@ -246,7 +248,7 @@ class CachedReferenceListOutputRenderer {
 		$container['revId'] = $revId;
 		$container['text'][$lang][$renderedReferenceListHash] = $renderedReferenceList;
 
-		$this->cache->save(
+		$this->cache->set(
 			$key,
 			$container
 		);

--- a/src/CitationReferencePositionJournal.php
+++ b/src/CitationReferencePositionJournal.php
@@ -2,10 +2,10 @@
 
 namespace SCI;
 
-use Onoi\Cache\Cache;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -16,7 +16,7 @@ use SMW\DataModel\SemanticData;
 class CitationReferencePositionJournal {
 
 	/**
-	 * @var Cache
+	 * @var BagOStuff
 	 */
 	private $cache = null;
 
@@ -33,10 +33,10 @@ class CitationReferencePositionJournal {
 	/**
 	 * @since 1.0
 	 *
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 * @param CacheKeyProvider $cacheKeyProvider
 	 */
-	public function __construct( Cache $cache, CacheKeyProvider $cacheKeyProvider ) {
+	public function __construct( BagOStuff $cache, CacheKeyProvider $cacheKeyProvider ) {
 		$this->cache = $cache;
 		$this->cacheKeyProvider = $cacheKeyProvider;
 	}
@@ -178,7 +178,7 @@ class CitationReferencePositionJournal {
 
 		// Safeguard against a repeated call to the hashlist for when the static
 		// cache is empty
-		$this->cache->save(
+		$this->cache->set(
 			$this->cacheKeyProvider->getCacheKeyForCitationReference( $hash ),
 			self::$citationReferenceJournal
 		);
@@ -186,7 +186,7 @@ class CitationReferencePositionJournal {
 
 	private function hasJournalForHash( $hash ) {
 		if ( self::$citationReferenceJournal === [] ) {
-			$cached = $this->cache->fetch(
+			$cached = $this->cache->get(
 				$this->cacheKeyProvider->getCacheKeyForCitationReference( $hash )
 			);
 			self::$citationReferenceJournal = is_array( $cached ) ? $cached : [];

--- a/src/FilteredMetadata/BibliographicFilteredRecord.php
+++ b/src/FilteredMetadata/BibliographicFilteredRecord.php
@@ -2,8 +2,6 @@
 
 namespace SCI\FilteredMetadata;
 
-use Onoi\Remi\FilteredRecord;
-
 /**
  * @license GPL-2.0-or-later
  * @since 1.0

--- a/src/FilteredMetadata/CrossRef/CrossRefCiteprocJsonProcessor.php
+++ b/src/FilteredMetadata/CrossRef/CrossRefCiteprocJsonProcessor.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace SCI\FilteredMetadata\CrossRef;
+
+use SCI\FilteredMetadata\FilteredRecord;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class CrossRefCiteprocJsonProcessor {
+
+	/**
+	 * @var FilteredRecord
+	 */
+	private $filteredRecord;
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 */
+	public function __construct( FilteredRecord $filteredRecord ) {
+		$this->filteredRecord = $filteredRecord;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param array $json
+	 */
+	public function doProcess( array $json ) {
+		$this->doProcessCiteproc( $json );
+	}
+
+	private function doProcessCiteproc( $citeproc ) {
+		foreach ( $citeproc as $key => $value ) {
+
+			switch ( $key ) {
+				case 'type':
+					$this->filteredRecord->set( 'type', $value );
+					break;
+				case 'subject':
+					$this->filteredRecord->set( 'subject', $value );
+					break;
+				case 'editor':
+				case 'author':
+					$this->collectAuthors( $key, $value );
+					break;
+				case 'title':
+					$this->filteredRecord->set( 'title', $value );
+					break;
+				case 'issue':
+					$this->filteredRecord->set( 'issue', $value );
+					break;
+				case 'volume':
+					$this->filteredRecord->set( 'volume', $value );
+					break;
+				case 'page':
+					$this->filteredRecord->set( 'pages', $value );
+					break;
+				case 'publisher':
+					$this->filteredRecord->set( 'publisher', $value );
+					break;
+				case 'container-title':
+					$this->filteredRecord->set( 'journal', $value );
+					break;
+				case 'DOI':
+					$this->filteredRecord->set( 'doi', $value );
+					break;
+				case 'ISSN':
+					$this->filteredRecord->set( 'issn', $value );
+					break;
+				case 'deposited': // Dataset
+				case 'issued':
+					if ( isset( $value['raw'] ) ) {
+						$this->filteredRecord->set( 'year', $value['raw'] );
+					} else {
+						$date = end( $value['date-parts'] );
+						$this->filteredRecord->set( 'year', $date[0] );
+					}
+
+					break;
+			}
+		}
+
+		// Part of the auto generated key
+		$this->filteredRecord->append(
+			'reference',
+			$this->filteredRecord->get( 'year' ) .
+			mb_substr( strtolower( $this->filteredRecord->get( 'title' ) ), 0, 2 )
+		);
+	}
+
+	private function collectAuthors( $name, array $values ) {
+		$authors = [];
+
+		foreach ( $values as $key => $value ) {
+
+			// Literal set by dataset
+			$familyName = isset( $value['literal'] ) ? $value['literal'] : $value['family'];
+
+			// Part of the auto generated key
+			if ( $key == 0 ) {
+				$this->filteredRecord->set( 'reference', strtolower( $familyName ) );
+			}
+
+			$authors[] = ( isset( $value['given'] ) ? $value['given'] . ' ' : '' ) . $familyName;
+		}
+
+		$this->filteredRecord->set( $name, $authors );
+	}
+
+}

--- a/src/FilteredMetadata/CrossRef/CrossRefFilteredHttpResponseParser.php
+++ b/src/FilteredMetadata/CrossRef/CrossRefFilteredHttpResponseParser.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SCI\FilteredMetadata\CrossRef;
+
+use SCI\FilteredMetadata\FilteredHttpResponseParser;
+use SCI\FilteredMetadata\HttpRequest;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class CrossRefFilteredHttpResponseParser extends FilteredHttpResponseParser {
+
+	/**
+	 * @see http://crosscite.org/cn/
+	 */
+	const CROSSREF_CONTENT_API = "https://dx.doi.org/";
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getRawResponseById( $doi ) {
+		return $this->requestResponseFor( $doi );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function doFilterResponseById( $doi ) {
+		$json = json_decode(
+			$this->requestResponseFor( $doi ),
+			true
+		);
+
+		if ( $this->httpRequest->getLastError() !== '' ) {
+			return $this->addMessage( [ 'onoi-remi-request-error', $this->httpRequest->getLastError(), $doi ] );
+		}
+
+		if ( $json === null || $json === [] ) {
+			return $this->addMessage( [ 'onoi-remi-response-empty', $doi ] );
+		}
+
+		$this->doProcessCiteproc( $json );
+
+		$this->filteredRecord->set( 'retrieved-from', self::CROSSREF_CONTENT_API );
+	}
+
+	private function doProcessCiteproc( $json ) {
+		$crossRefCiteprocJsonProcessor = new CrossRefCiteprocJsonProcessor(
+			$this->getFilteredRecord()
+		);
+
+		$crossRefCiteprocJsonProcessor->doProcess( $json );
+	}
+
+	/**
+	 * @param string $doi
+	 *
+	 * @return string
+	 */
+	private function requestResponseFor( $doi ) {
+		$this->httpRequest->setOption( HttpRequest::FOLLOW_LOCATION, true );
+
+		$this->httpRequest->setOption( HttpRequest::URL, self::CROSSREF_CONTENT_API . $doi );
+
+		$this->httpRequest->setOption( HttpRequest::HEADERS, [
+			'Accept: application/vnd.citationstyles.csl+json',
+			'Content-Type: application/x-www-form-urlencoded;charset=UTF-8'
+		] );
+
+		return $this->httpRequest->execute();
+	}
+
+}

--- a/src/FilteredMetadata/CrossRefResponseParser.php
+++ b/src/FilteredMetadata/CrossRefResponseParser.php
@@ -2,9 +2,8 @@
 
 namespace SCI\FilteredMetadata;
 
-use Onoi\Remi\CrossRef\CrossRefFilteredHttpResponseParser;
-use Onoi\Remi\ResponseParser;
 use SCI\DataValues\ResourceIdentifierFactory;
+use SCI\FilteredMetadata\CrossRef\CrossRefFilteredHttpResponseParser;
 
 /**
  * @license GPL-2.0-or-later

--- a/src/FilteredMetadata/FilteredHttpResponseParser.php
+++ b/src/FilteredMetadata/FilteredHttpResponseParser.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace SCI\FilteredMetadata;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+abstract class FilteredHttpResponseParser implements ResponseParser {
+
+	/**
+	 * @var HttpRequest
+	 */
+	protected $httpRequest;
+
+	/**
+	 * @var FilteredRecord
+	 */
+	protected $filteredRecord;
+
+	/**
+	 * @var array
+	 */
+	private $messages = [];
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param HttpRequest $httpRequest
+	 * @param FilteredRecord $filteredRecord
+	 */
+	public function __construct( HttpRequest $httpRequest, FilteredRecord $filteredRecord ) {
+		$this->httpRequest = $httpRequest;
+		$this->filteredRecord = $filteredRecord;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string[] $message
+	 */
+	public function addMessage( $message ) {
+		$this->messages[] = $message;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getMessages() {
+		return $this->messages;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getFilteredRecord() {
+		return $this->filteredRecord;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function usesCache() {
+		return $this->isFromCache();
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isFromCache() {
+		return $this->httpRequest->isCached();
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function doFilterResponseFor( $id ) {
+		return $this->doFilterResponseById( $id );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getRawResponse( $id ) {
+		return $this->getRawResponseById( $id );
+	}
+
+	/**
+	 * @since 0.3
+	 *
+	 * {@inheritDoc}
+	 */
+	abstract public function doFilterResponseById( $id );
+
+	/**
+	 * @since 0.3
+	 *
+	 * {@inheritDoc}
+	 */
+	abstract public function getRawResponseById( $id );
+
+}

--- a/src/FilteredMetadata/FilteredHttpResponseParserFactory.php
+++ b/src/FilteredMetadata/FilteredHttpResponseParserFactory.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace SCI\FilteredMetadata;
+
+use SCI\FilteredMetadata\CrossRef\CrossRefFilteredHttpResponseParser;
+use SCI\FilteredMetadata\Ncbi\NcbiPubMedFilteredHttpResponseParser;
+use SCI\FilteredMetadata\Oclc\OclcFilteredHttpResponseParser;
+use SCI\FilteredMetadata\OpenLibrary\OLFilteredHttpResponseParser;
+use SCI\FilteredMetadata\Viaf\ViafFilteredHttpResponseParser;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class FilteredHttpResponseParserFactory {
+
+	/**
+	 * @var HttpRequest
+	 */
+	private $httpRequest;
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param HttpRequest $httpRequest
+	 */
+	public function __construct( HttpRequest $httpRequest ) {
+		$this->httpRequest = $httpRequest;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 *
+	 * @return ResponseParser
+	 */
+	public function newCrossRefFilteredHttpResponseParser( FilteredRecord $filteredRecord ) {
+		return new CrossRefFilteredHttpResponseParser(
+			$this->httpRequest,
+			$filteredRecord
+		);
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 *
+	 * @return ResponseParser
+	 */
+	public function newViafFilteredHttpResponseParser( FilteredRecord $filteredRecord ) {
+		return new ViafFilteredHttpResponseParser(
+			$this->httpRequest,
+			$filteredRecord
+		);
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 *
+	 * @return ResponseParser
+	 */
+	public function newOclcFilteredHttpResponseParser( FilteredRecord $filteredRecord ) {
+		return new OclcFilteredHttpResponseParser(
+			$this->httpRequest,
+			$filteredRecord
+		);
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 *
+	 * @return ResponseParser
+	 */
+	public function newOLFilteredHttpResponseParser( FilteredRecord $filteredRecord ) {
+		return new OLFilteredHttpResponseParser(
+			$this->httpRequest,
+			$filteredRecord
+		);
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 *
+	 * @return ResponseParser
+	 */
+	public function newNcbiPubMedFilteredHttpResponseParser( FilteredRecord $filteredRecord ) {
+		$filteredRecord->set( 'ncbi-dbtype', 'pubmed' );
+
+		return new NcbiPubMedFilteredHttpResponseParser(
+			$this->httpRequest,
+			$filteredRecord
+		);
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 *
+	 * @return ResponseParser
+	 */
+	public function newNcbiPubMedCentralFilteredHttpResponseParser( FilteredRecord $filteredRecord ) {
+		$filteredRecord->set( 'ncbi-dbtype', 'pmc' );
+
+		return new NcbiPubMedFilteredHttpResponseParser(
+			$this->httpRequest,
+			$filteredRecord
+		);
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 *
+	 * @return ResponseParser
+	 */
+	public function newNullResponseParser( FilteredRecord $filteredRecord ) {
+		return new NullResponseParser( $filteredRecord );
+	}
+
+}

--- a/src/FilteredMetadata/FilteredRecord.php
+++ b/src/FilteredMetadata/FilteredRecord.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace SCI\FilteredMetadata;
+
+use InvalidArgumentException;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class FilteredRecord {
+
+	/**
+	 * @var array
+	 */
+	protected $recordFields = [];
+
+	/**
+	 * @var array
+	 */
+	private $redactedFields = [];
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param array $redactedFields
+	 */
+	public function setRedactedFields( array $redactedFields ) {
+		$this->redactedFields = array_flip( $redactedFields );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function set( $key, $value ) {
+		if ( isset( $this->redactedFields[$key] ) ) {
+			return null;
+		}
+
+		$this->recordFields[$key] = $value;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function append( $key, $value ) {
+		if ( isset( $this->redactedFields[$key] ) ) {
+			return null;
+		}
+
+		if ( !$this->has( $key ) ) {
+			$this->recordFields[$key] = [];
+		}
+
+		if ( is_array( $this->recordFields[$key] ) ) {
+			$this->recordFields[$key][] = $value;
+		} else {
+			$this->recordFields[$key] = $this->recordFields[$key] . $value;
+		}
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string $key
+	 *
+	 * @return bool
+	 */
+	public function has( $key ) {
+		return isset( $this->recordFields[$key] ) || array_key_exists( $key, $this->recordFields );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 * @throws InvalidArgumentException
+	 */
+	public function get( $key ) {
+		if ( $this->has( $key ) ) {
+			return $this->recordFields[$key];
+		}
+
+		throw new InvalidArgumentException( "{$key} is an unregistered field" );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string $key
+	 */
+	public function delete( $key ) {
+		unset( $this->recordFields[$key] );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @return array
+	 */
+	public function getRecordFields() {
+		return $this->recordFields;
+	}
+
+	/**
+	 * @since 0.2
+	 *
+	 * @param int $flags
+	 *
+	 * @return string
+	 */
+	public function asJsonString( $flags = 0 ) {
+		return json_encode( $this->recordFields, $flags );
+	}
+
+}

--- a/src/FilteredMetadata/HttpRequest.php
+++ b/src/FilteredMetadata/HttpRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace SCI\FilteredMetadata;
+
+/**
+ * Minimal HTTP client abstraction used by the bibliographic metadata response
+ * parsers.
+ *
+ * This replaces the former `onoi/http-request` dependency. Options are set via
+ * {@see HttpRequest::setOption} using the constants declared below;
+ * implementations issue the request using MediaWiki built-ins.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0
+ */
+interface HttpRequest {
+
+	/**
+	 * Target request URL (string).
+	 */
+	public const URL = 'url';
+
+	/**
+	 * Request headers as a list of "Header-Name: value" strings (string[]).
+	 */
+	public const HEADERS = 'headers';
+
+	/**
+	 * Whether to follow HTTP redirects (bool).
+	 */
+	public const FOLLOW_LOCATION = 'follow-location';
+
+	/**
+	 * Whether to issue the request as a POST (bool).
+	 */
+	public const POST = 'post';
+
+	/**
+	 * Raw POST body (string).
+	 */
+	public const POST_FIELDS = 'post-fields';
+
+	/**
+	 * Response cache lifetime in seconds (int).
+	 */
+	public const RESPONSE_CACHE_TTL = 'response-cache-ttl';
+
+	/**
+	 * Response cache key prefix (string).
+	 */
+	public const RESPONSE_CACHE_PREFIX = 'response-cache-prefix';
+
+	/**
+	 * @since 7.0
+	 *
+	 * @param string $name
+	 * @param mixed $value
+	 */
+	public function setOption( $name, $value );
+
+	/**
+	 * @since 7.0
+	 *
+	 * @return string Empty string when the last request succeeded.
+	 */
+	public function getLastError();
+
+	/**
+	 * @since 7.0
+	 *
+	 * @return bool Whether the last response was served from the cache.
+	 */
+	public function isCached();
+
+	/**
+	 * @since 7.0
+	 *
+	 * @return string The response body.
+	 */
+	public function execute();
+
+}

--- a/src/FilteredMetadata/HttpResponseParserFactory.php
+++ b/src/FilteredMetadata/HttpResponseParserFactory.php
@@ -2,9 +2,6 @@
 
 namespace SCI\FilteredMetadata;
 
-use Onoi\HttpRequest\HttpRequest;
-use Onoi\Remi\FilteredHttpResponseParserFactory;
-
 /**
  * @license GPL-2.0-or-later
  * @since 1.0

--- a/src/FilteredMetadata/MediaWikiHttpRequest.php
+++ b/src/FilteredMetadata/MediaWikiHttpRequest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace SCI\FilteredMetadata;
+
+use MediaWiki\Http\HttpRequestFactory;
+use Wikimedia\ObjectCache\BagOStuff;
+
+/**
+ * HTTP client backed by MediaWiki's `HttpRequestFactory` with an optional
+ * response cache layer.
+ *
+ * This replaces the former `onoi/http-request` `CachedCurlRequest`: it issues
+ * requests to the bibliographic metadata providers and caches successful
+ * responses, using only MediaWiki built-ins.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0
+ */
+class MediaWikiHttpRequest implements HttpRequest {
+
+	/**
+	 * Fixed cache key segment
+	 */
+	private const CACHE_PREFIX = 'sci:http:';
+
+	/**
+	 * @var HttpRequestFactory
+	 */
+	private $httpRequestFactory;
+
+	/**
+	 * @var BagOStuff
+	 */
+	private $cache;
+
+	/**
+	 * Per-request options, cleared after each {@see execute}.
+	 *
+	 * @var array
+	 */
+	private $options = [];
+
+	/**
+	 * Response cache lifetime in seconds; persists across requests. Defaults to
+	 * 60s (matching the former CachedCurlRequest); callers normally override it.
+	 *
+	 * @var int
+	 */
+	private $cacheTtl = 60;
+
+	/**
+	 * Response cache key prefix; persists across requests.
+	 *
+	 * @var string
+	 */
+	private $cachePrefix = '';
+
+	/**
+	 * @var string
+	 */
+	private $lastError = '';
+
+	/**
+	 * @var bool
+	 */
+	private $isFromCache = false;
+
+	/**
+	 * @since 7.0
+	 *
+	 * @param HttpRequestFactory $httpRequestFactory
+	 * @param BagOStuff $cache
+	 */
+	public function __construct( HttpRequestFactory $httpRequestFactory, BagOStuff $cache ) {
+		$this->httpRequestFactory = $httpRequestFactory;
+		$this->cache = $cache;
+	}
+
+	/**
+	 * @since 7.0
+	 *
+	 * @param string $name
+	 * @param mixed $value
+	 */
+	public function setOption( $name, $value ) {
+		if ( $name === self::RESPONSE_CACHE_TTL ) {
+			$this->cacheTtl = (int)$value;
+			return;
+		}
+
+		if ( $name === self::RESPONSE_CACHE_PREFIX ) {
+			$this->cachePrefix = (string)$value;
+			return;
+		}
+
+		$this->options[$name] = $value;
+	}
+
+	/**
+	 * @since 7.0
+	 *
+	 * @return string
+	 */
+	public function getLastError() {
+		return $this->lastError;
+	}
+
+	/**
+	 * @since 7.0
+	 *
+	 * @return bool
+	 */
+	public function isCached() {
+		return $this->isFromCache;
+	}
+
+	/**
+	 * @since 7.0
+	 *
+	 * @return string
+	 */
+	public function execute() {
+		$this->lastError = '';
+		$this->isFromCache = false;
+
+		$key = $this->makeCacheKey();
+		$cached = $this->cache->get( $key );
+
+		if ( $cached !== false ) {
+			$this->isFromCache = true;
+			$this->options = [];
+			return $cached;
+		}
+
+		$response = $this->doRequest();
+
+		// Do not cache a failed response.
+		if ( $this->lastError === '' ) {
+			$this->cache->set( $key, $response, $this->cacheTtl );
+		}
+
+		$this->options = [];
+
+		return $response;
+	}
+
+	/**
+	 * @return string
+	 */
+	private function doRequest() {
+		$url = (string)( $this->options[self::URL] ?? '' );
+		$requestOptions = [];
+
+		if ( !empty( $this->options[self::FOLLOW_LOCATION] ) ) {
+			$requestOptions['followRedirects'] = true;
+		}
+
+		if ( !empty( $this->options[self::POST] ) ) {
+			$requestOptions['method'] = 'POST';
+			$requestOptions['postData'] = (string)( $this->options[self::POST_FIELDS] ?? '' );
+		}
+
+		try {
+			$request = $this->httpRequestFactory->create( $url, $requestOptions, __METHOD__ );
+
+			foreach ( (array)( $this->options[self::HEADERS] ?? [] ) as $header ) {
+				if ( strpos( (string)$header, ':' ) === false ) {
+					continue;
+				}
+
+				[ $name, $value ] = explode( ':', $header, 2 );
+				$request->setHeader( trim( $name ), trim( $value ) );
+			}
+
+			$status = $request->execute();
+		} catch ( \Throwable $e ) {
+			$this->lastError = $e->getMessage();
+			return '';
+		}
+
+		if ( !$status->isOK() ) {
+			$httpCode = $request->getStatus();
+			$this->lastError = $httpCode ? 'HTTP ' . $httpCode : 'request-failed';
+
+			// Mirror the former cURL CURLOPT_FAILONERROR behaviour: a failed
+			// request yields no body (the parsers short-circuit on getLastError).
+			return '';
+		}
+
+		return (string)$request->getContent();
+	}
+
+	/**
+	 * Builds a stable cache key from the request-defining options.
+	 *
+	 * @return string
+	 */
+	private function makeCacheKey() {
+		$parts = [
+			'url' => $this->options[self::URL] ?? '',
+			'headers' => $this->options[self::HEADERS] ?? [],
+			'follow' => (bool)( $this->options[self::FOLLOW_LOCATION] ?? false ),
+			'post' => (bool)( $this->options[self::POST] ?? false ),
+			'post-fields' => $this->options[self::POST_FIELDS] ?? '',
+		];
+
+		return $this->cachePrefix . self::CACHE_PREFIX . md5( (string)json_encode( $parts ) );
+	}
+
+}

--- a/src/FilteredMetadata/Ncbi/NcbiEntrezAbstractXMLProcessor.php
+++ b/src/FilteredMetadata/Ncbi/NcbiEntrezAbstractXMLProcessor.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace SCI\FilteredMetadata\Ncbi;
+
+use DOMDocument;
+use SCI\FilteredMetadata\FilteredRecord;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class NcbiEntrezAbstractXMLProcessor {
+
+	/**
+	 * @var FilteredRecord
+	 */
+	private $filteredRecord;
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 */
+	public function __construct( FilteredRecord $filteredRecord ) {
+		$this->filteredRecord = $filteredRecord;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string $xml
+	 */
+	public function doProcess( $xml ) {
+		$domDocument = new DOMDocument();
+		$domDocument->loadXml( $xml );
+
+		$this->findElementsForPubMed( $domDocument );
+		$this->findElementsForPubMedCentral( $domDocument );
+	}
+
+	private function findElementsForPubMed( DOMDocument $domDocument ) {
+		foreach ( $domDocument->getElementsByTagName( 'PubDate' ) as $item ) {
+			foreach ( $item->getElementsByTagName( 'Year' ) as $i ) {
+				$this->filteredRecord->set( 'year', $i->nodeValue );
+			}
+		}
+
+		foreach ( $domDocument->getElementsByTagName( 'Abstract' ) as $item ) {
+			$this->filteredRecord->set( 'abstract', preg_replace( '#\s{2,}#', ' ', trim( $item->nodeValue ) ) );
+		}
+
+		foreach ( $domDocument->getElementsByTagName( 'MeshHeading' ) as $item ) {
+			$this->filteredRecord->append( 'subject', preg_replace( '#\s{2,}#', ' ', trim( $item->nodeValue ) ) );
+		}
+
+		// http://www.library.illinois.edu/biotech/j-abbrev.html notes:
+		// "... database uses the "standard abbreviation", as defined by ISSN
+		// and used also by BIOSIS and CASSI ..."
+		foreach ( $domDocument->getElementsByTagName( 'ISOAbbreviation' ) as $item ) {
+			$this->filteredRecord->append( 'iso-abbreviation', trim( $item->nodeValue ) );
+		}
+	}
+
+	private function findElementsForPubMedCentral( DOMDocument $domDocument ) {
+		foreach ( $domDocument->getElementsByTagName( 'pub-date' ) as $item ) {
+			foreach ( $item->getElementsByTagName( 'year' ) as $i ) {
+				$this->filteredRecord->set( 'year', $i->nodeValue );
+			}
+		}
+
+		foreach ( $domDocument->getElementsByTagName( 'abstract' ) as $item ) {
+			$this->filteredRecord->set( 'abstract', preg_replace( '#\s{2,}#', ' ', trim( $item->nodeValue ) ) );
+		}
+
+		foreach ( $domDocument->getElementsByTagName( 'article' ) as $item ) {
+			$this->filteredRecord->set( 'type', $item->getAttribute( 'article-type' ) );
+		}
+	}
+
+}

--- a/src/FilteredMetadata/Ncbi/NcbiPubMedFilteredHttpResponseParser.php
+++ b/src/FilteredMetadata/Ncbi/NcbiPubMedFilteredHttpResponseParser.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace SCI\FilteredMetadata\Ncbi;
+
+use SCI\FilteredMetadata\FilteredHttpResponseParser;
+use SCI\FilteredMetadata\HttpRequest;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class NcbiPubMedFilteredHttpResponseParser extends FilteredHttpResponseParser {
+
+	/**
+	 * @see http://www.ncbi.nlm.nih.gov/books/NBK25501/
+	 * @see http://www.ncbi.nlm.nih.gov/books/NBK1058/
+	 */
+	const SUMMARY_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?";
+	const FETCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?";
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getRawResponseById( $id ) {
+		$db = $this->filteredRecord->get( 'ncbi-dbtype' );
+
+		return $this->requestSummaryResponseFor( $id, $db ) . $this->requestAbstractResponseFor( $id, $db );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function doFilterResponseById( $id ) {
+		$db = $this->filteredRecord->get( 'ncbi-dbtype' );
+
+		$text = $this->requestSummaryResponseFor( $id, $db );
+
+		if ( $this->httpRequest->getLastError() !== '' ) {
+			return $this->addMessage( [ 'onoi-remi-request-error', $this->httpRequest->getLastError(), $id ] );
+		}
+
+		$this->doProcessSummary( $text, $id, $db );
+
+		if ( $this->getMessages() !== [] ) {
+			return null;
+		}
+
+		$this->doProcessAbstract(
+			$this->requestAbstractResponseFor( $id, $db )
+		);
+	}
+
+	private function doProcessSummary( $text, $id, $db ) {
+		$result = json_decode(
+			$text,
+			true
+		);
+
+		if ( !isset( $result['result'][$id] ) ) {
+			return $this->addMessage( [ 'onoi-remi-response-empty', $id ] );
+		}
+
+		$record = $result['result'][$id];
+
+		if ( isset( $record['error'] ) ) {
+			return $this->addMessage( [ 'onoi-remi-request-error', $record['error'], $id ] );
+		}
+
+		if ( isset( $record['pubtype'] ) ) {
+			foreach ( $record['pubtype'] as $type ) {
+				$this->filteredRecord->append( 'type', $type );
+			}
+		}
+
+		foreach ( $record['articleids'] as $articleids ) {
+
+			if ( $articleids['idtype'] === 'doi' ) {
+				$this->filteredRecord->set( 'doi', $articleids['value'] );
+			}
+
+			if ( $articleids['idtype'] === 'pmid' ) {
+				$this->filteredRecord->set( 'pmid', $articleids['value'] );
+			}
+
+			if ( $articleids['idtype'] === 'pubmed' ) {
+				$this->filteredRecord->set( 'pmid', $articleids['value'] );
+			}
+
+			if ( $articleids['idtype'] === 'pmcid' && $db === 'pmc' ) {
+				$this->filteredRecord->set( 'pmcid', $articleids['value'] );
+			}
+
+			if ( $articleids['idtype'] === 'pmc' && $db === 'pubmed' ) {
+				$this->filteredRecord->set( 'pmcid', $articleids['value'] );
+			}
+		}
+
+		foreach ( $record['authors'] as $author ) {
+			$this->filteredRecord->append( 'author', $author['name'] );
+		}
+
+		$this->filteredRecord->set( 'title', $record['title'] );
+		$this->filteredRecord->set( 'journal', $record['fulljournalname'] );
+		$this->filteredRecord->set( 'pubdate', $record['pubdate'] );
+		$this->filteredRecord->set( 'volume', $record['volume'] );
+		$this->filteredRecord->set( 'issue', $record['issue'] );
+		$this->filteredRecord->set( 'pages', $record['pages'] );
+
+		$this->filteredRecord->set( 'retrieved-from', 'http://www.ncbi.nlm.nih.gov/' );
+	}
+
+	private function doProcessAbstract( $xml ) {
+		$ncbiEntrezAbstractXMLProcessor = new NcbiEntrezAbstractXMLProcessor(
+			$this->filteredRecord
+		);
+
+		$ncbiEntrezAbstractXMLProcessor->doProcess( $xml );
+	}
+
+	/**
+	 * @param string $id
+	 *
+	 * @return string
+	 */
+	public function requestSummaryResponseFor( $id, $type ) {
+		$this->httpRequest->setOption( HttpRequest::URL, self::SUMMARY_URL );
+
+		$this->httpRequest->setOption( HttpRequest::HEADERS, [
+			'Accept: application/sparql-results+json, application/rdf+json, application/json',
+			'Content-Type: application/x-www-form-urlencoded;charset=UTF-8'
+		] );
+
+		$this->httpRequest->setOption( HttpRequest::POST, true );
+
+		$this->httpRequest->setOption(
+			HttpRequest::POST_FIELDS,
+			"db={$type}&retmode=json&id=" . $id
+		);
+
+		return $this->httpRequest->execute();
+	}
+
+	/**
+	 * @param string $id
+	 *
+	 * @return string
+	 */
+	public function requestAbstractResponseFor( $id, $type ) {
+		// http://www.fredtrotter.com/2014/11/14/hacking-on-the-pubmed-api/
+
+		$this->httpRequest->setOption( HttpRequest::URL, self::FETCH_URL );
+
+		$this->httpRequest->setOption( HttpRequest::HEADERS, [
+			'Accept: application/sparql-results+xml, application/rdf+xml, application/xml',
+			'Content-Type: application/x-www-form-urlencoded;charset=UTF-8'
+		] );
+
+		$this->httpRequest->setOption( HttpRequest::POST, true );
+
+		$this->httpRequest->setOption(
+			HttpRequest::POST_FIELDS,
+			"db={$type}&rettype=abstract&retmode=xml&id=" . $id
+		);
+
+		return $this->httpRequest->execute();
+	}
+
+}

--- a/src/FilteredMetadata/NcbiPubMedResponseParser.php
+++ b/src/FilteredMetadata/NcbiPubMedResponseParser.php
@@ -2,9 +2,8 @@
 
 namespace SCI\FilteredMetadata;
 
-use Onoi\Remi\Ncbi\NcbiPubMedFilteredHttpResponseParser;
-use Onoi\Remi\ResponseParser;
 use SCI\DataValues\ResourceIdentifierFactory;
+use SCI\FilteredMetadata\Ncbi\NcbiPubMedFilteredHttpResponseParser;
 
 /**
  * @license GPL-2.0-or-later

--- a/src/FilteredMetadata/NullResponseParser.php
+++ b/src/FilteredMetadata/NullResponseParser.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SCI\FilteredMetadata;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class NullResponseParser implements ResponseParser {
+
+	/**
+	 * @var FilteredRecord
+	 */
+	private $filteredRecord;
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 */
+	public function __construct( FilteredRecord $filteredRecord ) {
+		$this->filteredRecord = $filteredRecord;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getFilteredRecord() {
+		return $this->filteredRecord;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getMessages() {
+		return [];
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function usesCache() {
+		return false;
+	}
+
+	/**
+	 * @since 0.3
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isFromCache() {
+		return false;
+	}
+
+	/**
+	 * @since 0.3
+	 *
+	 * {@inheritDoc}
+	 */
+	public function doFilterResponseById( $query ) {
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function doFilterResponseFor( $query ) {
+	}
+
+	/**
+	 * @since 0.3
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getRawResponseById( $query ) {
+		return '';
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getRawResponse( $query ) {
+		return '';
+	}
+
+}

--- a/src/FilteredMetadata/OLResponseParser.php
+++ b/src/FilteredMetadata/OLResponseParser.php
@@ -2,8 +2,7 @@
 
 namespace SCI\FilteredMetadata;
 
-use Onoi\Remi\OpenLibrary\OLFilteredHttpResponseParser;
-use Onoi\Remi\ResponseParser;
+use SCI\FilteredMetadata\OpenLibrary\OLFilteredHttpResponseParser;
 
 /**
  * @license GPL-2.0-or-later

--- a/src/FilteredMetadata/Oclc/OclcFilteredHttpResponseParser.php
+++ b/src/FilteredMetadata/Oclc/OclcFilteredHttpResponseParser.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SCI\FilteredMetadata\Oclc;
+
+use SCI\FilteredMetadata\FilteredHttpResponseParser;
+use SCI\FilteredMetadata\HttpRequest;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class OclcFilteredHttpResponseParser extends FilteredHttpResponseParser {
+
+	/**
+	 * @see http://dataliberate.com/2013/06/content-negotiation-for-worldcat/
+	 */
+	const OCLC_REST = "http://www.worldcat.org/oclc/";
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getRawResponseById( $oclcID ) {
+		return $this->requestResponseFor( $oclcID );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function doFilterResponseById( $oclcID ) {
+		$text = $this->requestResponseFor( $oclcID );
+
+		if ( $this->httpRequest->getLastError() !== '' ) {
+			return $this->addMessage( [ 'onoi-remi-request-error', $this->httpRequest->getLastError(), $oclcID ] );
+		}
+
+		$jsonld = json_decode( $text, true );
+
+		if ( $jsonld === null || $jsonld === '' ) {
+			return $this->addMessage( [ 'onoi-remi-response-empty', $oclcID ] );
+		}
+
+		$this->doProcessJsonLd( $oclcID, $jsonld );
+
+		$this->filteredRecord->set( 'retrieved-from', 'http://www.worldcat.org/' );
+	}
+
+	private function doProcessJsonLd( $oclcID, $jsonld ) {
+		$simpleOclcJsonLdGraphProcessor = new SimpleOclcJsonLdGraphProcessor(
+			$this->filteredRecord
+		);
+
+		$simpleOclcJsonLdGraphProcessor->doProcess( $oclcID, $jsonld );
+	}
+
+	/**
+	 * @param string $id
+	 *
+	 * @return string
+	 */
+	public function requestResponseFor( $id ) {
+		$this->httpRequest->setOption( HttpRequest::FOLLOW_LOCATION, true );
+
+		$this->httpRequest->setOption( HttpRequest::URL, self::OCLC_REST . $id );
+
+		$this->httpRequest->setOption( HttpRequest::HEADERS, [
+			'Accept: application/ld+json',
+			'Content-Type: application/x-www-form-urlencoded;charset=UTF-8'
+		] );
+
+		return $this->httpRequest->execute();
+	}
+
+}

--- a/src/FilteredMetadata/Oclc/SimpleOclcJsonLdGraphProcessor.php
+++ b/src/FilteredMetadata/Oclc/SimpleOclcJsonLdGraphProcessor.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace SCI\FilteredMetadata\Oclc;
+
+use SCI\FilteredMetadata\FilteredRecord;
+
+/**
+ * This is a very simple graph parser for metadata we want to harvest from a
+ * REST response.
+ *
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class SimpleOclcJsonLdGraphProcessor {
+
+	/**
+	 * @var FilteredRecord
+	 */
+	private $filteredRecord;
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 */
+	public function __construct( FilteredRecord $filteredRecord ) {
+		$this->filteredRecord = $filteredRecord;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string $oclcID
+	 * @param array $jsonld
+	 */
+	public function doProcess( $oclcID, array $jsonld ) {
+		foreach ( $jsonld as $graph ) {
+			$this->doProcessGraphElementsFor( $oclcID, $graph );
+		}
+	}
+
+	/**
+	 * @param string $oclcID
+	 * @param array $graph
+	 */
+	private function doProcessGraphElementsFor( $oclcID, array $graph ) {
+		foreach ( $graph as $element ) {
+			$this->doProcessOtherElements( $element );
+
+			// Looking for the tree component that hosts the metadata
+			if ( ( isset( $element['oclcnum'] ) && $element['oclcnum'] == $oclcID ) ||
+				( isset( $element['library:oclcnum'] ) && $element['library:oclcnum'] == $oclcID ) ) {
+				$this->doProcessTheAboutElement( $element );
+			}
+		}
+	}
+
+	private function doProcessOtherElements( $element ) {
+		if ( isset( $element['isbn'] ) ) {
+			$this->collectIsbn( $element['isbn'] );
+		}
+
+		// Looking only for an entity of schema:Person
+		if ( isset( $element['@type'] ) && $element['@type'] === 'schema:Person' && strpos( $element['@id'], 'viaf' ) !== false ) {
+			$this->filteredRecord->append(
+				'viaf',
+				substr( $element['@id'], strrpos( $element['@id'], '/' ) + 1 ) // get the ID not the URL
+			);
+			$this->filteredRecord->append( 'author', $element['name'] );
+		}
+
+		// Looking only for an entity of schema:Intangible
+		if ( isset( $element['@type'] ) && $element['@type'] === 'schema:Intangible' && isset( $element['name']['@value'] ) ) {
+			$this->filteredRecord->append( 'subject', $element['name']['@value'] );
+		}
+	}
+
+	private function doProcessTheAboutElement( array $values ) {
+		foreach ( $values as $key => $value ) {
+
+			switch ( $key ) {
+				case '@id':
+					$this->filteredRecord->set( 'url', $value );
+					break;
+				case '@type':
+					$this->filteredRecord->set( 'type', is_string( $value ) ? [ $value ] : $value );
+					break;
+				case 'datePublished':
+					$this->filteredRecord->set( 'pubdate', $value );
+					break;
+				case 'description':
+					$this->collectAbstract( $value );
+					break;
+				case 'bookEdition':
+					$this->filteredRecord->set( 'edition', $value );
+					break;
+				case 'name':
+					$this->filteredRecord->set( 'title', is_array( $value ) ? $value['@value'] : $value );
+					break;
+				case 'genre':
+					$this->collectGenre( $value );
+					break;
+			}
+		}
+	}
+
+	private function collectIsbn( array $values ) {
+		foreach ( $values as $value ) {
+			$this->filteredRecord->append( 'isbn', $value );
+		}
+	}
+
+	private function collectGenre( $values ) {
+		foreach ( $values as $key => $value ) {
+
+			if ( is_array( $value ) ) {
+				$this->collectGenre( $value );
+				continue;
+			}
+
+			if ( $key === '@value' ) {
+				$this->filteredRecord->append( 'genre', $value );
+			}
+		}
+	}
+
+	private function collectAbstract( $values ) {
+		foreach ( $values as $key => $value ) {
+
+			if ( is_array( $value ) ) {
+				$this->collectAbstract( $value );
+				continue;
+			}
+
+			// This is pure guess work since the description list is
+			// an unordered list with no indication of what type of
+			// content is stored, use `--` is indicator that is not
+			// the abstract
+			if ( strpos( $value, '--' ) !== false ) {
+				continue;
+			}
+
+			if ( $key === '@value' ) {
+				$this->filteredRecord->append( 'abstract', $value );
+			}
+		}
+	}
+
+}

--- a/src/FilteredMetadata/OclcResponseParser.php
+++ b/src/FilteredMetadata/OclcResponseParser.php
@@ -2,9 +2,8 @@
 
 namespace SCI\FilteredMetadata;
 
-use Onoi\Remi\Oclc\OclcFilteredHttpResponseParser;
-use Onoi\Remi\ResponseParser;
 use SCI\DataValues\ResourceIdentifierFactory;
+use SCI\FilteredMetadata\Oclc\OclcFilteredHttpResponseParser;
 
 /**
  * @license GPL-2.0-or-later

--- a/src/FilteredMetadata/OpenLibrary/OLBooksAPIJsonProcessor.php
+++ b/src/FilteredMetadata/OpenLibrary/OLBooksAPIJsonProcessor.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace SCI\FilteredMetadata\OpenLibrary;
+
+use SCI\FilteredMetadata\FilteredRecord;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class OLBooksAPIJsonProcessor {
+
+	/**
+	 * @var FilteredRecord
+	 */
+	private $filteredRecord;
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param FilteredRecord $filteredRecord
+	 */
+	public function __construct( FilteredRecord $filteredRecord ) {
+		$this->filteredRecord = $filteredRecord;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param array $json
+	 */
+	public function doProcess( array $json ) {
+		foreach ( $json as $key => $record ) {
+			$this->doProcessElements( $record );
+		}
+	}
+
+	private function doProcessElements( $record ) {
+		foreach ( $record as $key => $value ) {
+
+			switch ( $key ) {
+				case 'title':
+					$this->filteredRecord->set( 'title', $value );
+					break;
+				case 'subtitle':
+					$this->filteredRecord->set( 'subtitle', $value );
+					break;
+				case 'url':
+					$this->filteredRecord->set( 'url', $value );
+					break;
+				case 'publishers':
+					$this->filteredRecord->set( 'publisher', end( $value ) );
+					break;
+				case 'publish_date':
+					$this->filteredRecord->set( 'pubdate', $value );
+					break;
+				case 'number_of_pages':
+					$this->filteredRecord->set( 'pages', $value );
+					break;
+				case 'classifications':
+					$this->collectClassifications( $value );
+					break;
+				case 'identifiers':
+					$this->collectIdentifiers( $value );
+					break;
+				case 'subject_places':
+				case 'subjects':
+					$this->collectSubjects( $value );
+					break;
+				case 'authors':
+					$this->collectAuthors( $value );
+					break;
+				case 'cover':
+					$this->filteredRecord->set( 'cover', end( $value ) );
+					break;
+			}
+		}
+	}
+
+	private function collectClassifications( $value ) {
+		foreach ( $value as $id => $v ) {
+			$this->filteredRecord->append( str_replace( '_', ' ', $id ), end( $v ) );
+		}
+	}
+
+	private function collectSubjects( $value ) {
+		foreach ( $value as $id => $v ) {
+			$this->filteredRecord->append( 'subject', $v['name'] );
+		}
+	}
+
+	private function collectAuthors( $value ) {
+		foreach ( $value as $id => $v ) {
+			$this->filteredRecord->append( 'author', $v['name'] );
+		}
+	}
+
+	private function collectIdentifiers( $value ) {
+		foreach ( $value as $id => $v ) {
+
+			if ( $id === 'openlibrary' ) {
+				$id = 'olid';
+			}
+
+			if ( $id === 'isbn_13' || $id === 'isbn_10' ) {
+				$id = 'isbn';
+			}
+
+			// No commercial provider
+			if ( !in_array( $id, [ 'isbn', 'olid', 'oclc', 'lccn' ] ) ) {
+				continue;
+			}
+
+			$this->filteredRecord->append( $id, end( $v ) );
+		}
+	}
+
+}

--- a/src/FilteredMetadata/OpenLibrary/OLFilteredHttpResponseParser.php
+++ b/src/FilteredMetadata/OpenLibrary/OLFilteredHttpResponseParser.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SCI\FilteredMetadata\OpenLibrary;
+
+use SCI\FilteredMetadata\FilteredHttpResponseParser;
+use SCI\FilteredMetadata\HttpRequest;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class OLFilteredHttpResponseParser extends FilteredHttpResponseParser {
+
+	/**
+	 * @see https://openlibrary.org/dev/docs/api/books
+	 */
+	const OL_REST = "https://openlibrary.org/api/";
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getRawResponseById( $olID ) {
+		return $this->requestResponseFor( $olID );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function doFilterResponseById( $olID ) {
+		$text = $this->requestResponseFor( $olID );
+
+		if ( $this->httpRequest->getLastError() !== '' ) {
+			return $this->addMessage( [ 'onoi-remi-request-error', $this->httpRequest->getLastError(), $olID ] );
+		}
+
+		$json = json_decode(
+			$text,
+			true
+		);
+
+		if ( $json === null || $json === '' || $json === [] ) {
+			return $this->addMessage( [ 'onoi-remi-response-empty', $olID ] );
+		}
+
+		$this->doProcessJson( $json );
+
+		$this->filteredRecord->set( 'retrieved-from', 'https://openlibrary.org/' );
+	}
+
+	private function doProcessJson( $json ) {
+		$olBooksAPIJsonProcessor = new OLBooksAPIJsonProcessor(
+			$this->filteredRecord
+		);
+
+		$olBooksAPIJsonProcessor->doProcess( $json );
+	}
+
+	/**
+	 * @see https://openlibrary.org/dev/docs/api/books#data
+	 *
+	 * @param string $id
+	 *
+	 * @return string
+	 */
+	private function requestResponseFor( $id ) {
+		$this->httpRequest->setOption( HttpRequest::FOLLOW_LOCATION, true );
+
+		$this->httpRequest->setOption( HttpRequest::HEADERS, [
+			'Accept: application/json',
+			'Content-type: application/json; charset=utf-8'
+		] );
+
+		$this->httpRequest->setOption(
+			HttpRequest::URL,
+			self::OL_REST . "books?bibkeys=" . 'OLID:' . $id . ',ISBN:' . $id . '&format=json&jscmd=data' );
+
+		return $this->httpRequest->execute();
+	}
+
+}

--- a/src/FilteredMetadata/ResponseParser.php
+++ b/src/FilteredMetadata/ResponseParser.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SCI\FilteredMetadata;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+interface ResponseParser {
+
+	/**
+	 * @since 0.1
+	 *
+	 * @return FilteredRecord
+	 */
+	public function getFilteredRecord();
+
+	/**
+	 * @since 0.1
+	 *
+	 * @return array
+	 */
+	public function getMessages();
+
+	/**
+	 * @since 0.1
+	 *
+	 * @return bool
+	 */
+	public function usesCache();
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string $id
+	 */
+	public function doFilterResponseFor( $id );
+
+	/**
+	 * @since 0.1
+	 *
+	 * @param string $id
+	 *
+	 * @return string
+	 */
+	public function getRawResponse( $id );
+
+}

--- a/src/FilteredMetadata/Viaf/ViafFilteredHttpResponseParser.php
+++ b/src/FilteredMetadata/Viaf/ViafFilteredHttpResponseParser.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace SCI\FilteredMetadata\Viaf;
+
+use DOMDocument;
+use SCI\FilteredMetadata\FilteredHttpResponseParser;
+use SCI\FilteredMetadata\HttpRequest;
+
+/**
+ * @license GPL-2.0-or-later
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class ViafFilteredHttpResponseParser extends FilteredHttpResponseParser {
+
+	/**
+	 * @see http://crosscite.org/cn/
+	 */
+	const VIAF_REST = "http://viaf.org/viaf/";
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getRawResponseById( $viafID ) {
+		return $this->requestResponseFor( $viafID );
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function doFilterResponseById( $viafID ) {
+		$xml = $this->requestResponseFor( $viafID );
+
+		if ( $this->httpRequest->getLastError() !== '' ) {
+			return $this->addMessage( [ 'onoi-remi-request-error', $this->httpRequest->getLastError(), $viafID ] );
+		}
+
+		if ( $xml === null || $xml === '' || $xml === false ) {
+			return $this->addMessage( [ 'onoi-remi-response-empty', $viafID ] );
+		}
+
+		$dom = new DOMDocument();
+		$dom->loadXml( $xml );
+
+		$this->doProcessDom( $dom, $viafID );
+
+		$this->filteredRecord->set( 'retrieved-from', 'http://viaf.org/' );
+	}
+
+	private function doProcessDom( $dom, $viafID ) {
+		$viaf = '';
+
+		foreach ( $dom->getElementsByTagName( 'viafID' ) as $item ) {
+			$viaf = $item->nodeValue;
+		}
+
+		if ( $viaf != $viafID ) {
+			return $this->addMessage( [ 'onoi-remi-parser-no-id-match', $viafID ] );
+		}
+
+		$this->filteredRecord->set( 'viaf', $viafID );
+
+		foreach ( $dom->getElementsByTagName( 'nameType' ) as $item ) {
+			$this->filteredRecord->set( 'type', $item->nodeValue );
+		}
+
+		foreach ( $dom->getElementsByTagName( 'sources' ) as $item ) {
+			foreach ( $item->getElementsByTagName( 'source' ) as $i ) {
+				[ $key, $value ] = explode( '|', $i->nodeValue, 2 );
+				$this->filteredRecord->set( strtolower( $key ), str_replace( ' ', '', $value ) );
+			}
+		}
+
+		// Not sure what we want to search/iterate for therefore stop after the
+		// first data/name element
+		foreach ( $dom->getElementsByTagName( 'data' ) as $item ) {
+
+			foreach ( $item->getElementsByTagName( 'text' ) as $i ) {
+				$this->filteredRecord->set( 'name', str_replace( '.', '', $i->nodeValue ) );
+				break;
+			}
+
+			break;
+		}
+	}
+
+	/**
+	 * @param string $id
+	 *
+	 * @return string
+	 */
+	private function requestResponseFor( $id ) {
+		$this->httpRequest->setOption( HttpRequest::FOLLOW_LOCATION, true );
+
+		$this->httpRequest->setOption( HttpRequest::URL, self::VIAF_REST . $id );
+
+		$this->httpRequest->setOption( HttpRequest::HEADERS, [
+			'Accept: application/xml',
+			'Content-Type: application/x-www-form-urlencoded;charset=UTF-8'
+		] );
+
+		return $this->httpRequest->execute();
+	}
+
+}

--- a/src/FilteredMetadata/ViafResponseParser.php
+++ b/src/FilteredMetadata/ViafResponseParser.php
@@ -2,9 +2,8 @@
 
 namespace SCI\FilteredMetadata;
 
-use Onoi\Remi\ResponseParser;
-use Onoi\Remi\Viaf\ViafFilteredHttpResponseParser;
 use SCI\DataValues\ResourceIdentifierFactory;
+use SCI\FilteredMetadata\Viaf\ViafFilteredHttpResponseParser;
 
 /**
  * @license GPL-2.0-or-later

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -2,12 +2,12 @@
 
 namespace SCI;
 
-use Onoi\Cache\Cache;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\WikiPage;
 use SMW\DataTypeRegistry;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -36,10 +36,10 @@ class HookRegistry {
 	 * @since 1.0
 	 *
 	 * @param Store $store
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 * @param Options $options
 	 */
-	public function __construct( Store $store, Cache $cache, Options $options ) {
+	public function __construct( Store $store, BagOStuff $cache, Options $options ) {
 		$this->options = $options;
 
 		$this->addCallbackHandlers(

--- a/src/ReferenceListFactory.php
+++ b/src/ReferenceListFactory.php
@@ -2,10 +2,10 @@
 
 namespace SCI;
 
-use Onoi\Cache\Cache;
 use SMW\NamespaceExaminer;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -65,13 +65,13 @@ class ReferenceListFactory {
 	 * @since  1.0
 	 *
 	 * @param MediaWikiContextInteractor $contextInteractor
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 * @param CacheKeyProvider $cacheKeyProvider
 	 * @param Options $options
 	 *
 	 * @return CachedReferenceListOutputRenderer
 	 */
-	public function newCachedReferenceListOutputRenderer( MediaWikiContextInteractor $contextInteractor, Cache $cache, CacheKeyProvider $cacheKeyProvider, Options $options ) {
+	public function newCachedReferenceListOutputRenderer( MediaWikiContextInteractor $contextInteractor, BagOStuff $cache, CacheKeyProvider $cacheKeyProvider, Options $options ) {
 		$referenceListOutputRenderer = $this->newReferenceListOutputRenderer();
 
 		$referenceListOutputRenderer->setNumberOfReferenceListColumns(

--- a/src/Specials/CitableMetadata/HtmlResponseParserRenderer.php
+++ b/src/Specials/CitableMetadata/HtmlResponseParserRenderer.php
@@ -3,7 +3,7 @@
 namespace SCI\Specials\CitableMetadata;
 
 use MediaWiki\Html\Html;
-use Onoi\Remi\ResponseParser;
+use SCI\FilteredMetadata\ResponseParser;
 
 /**
  * @license GPL-2.0-or-later

--- a/src/Specials/SpecialFindCitableMetadata.php
+++ b/src/Specials/SpecialFindCitableMetadata.php
@@ -4,9 +4,9 @@ namespace SCI\Specials;
 
 use MediaWiki\MediaWikiServices;
 use MediaWiki\SpecialPage\SpecialPage;
-use Onoi\HttpRequest\HttpRequestFactory;
 use SCI\CitationResourceMatchFinder;
 use SCI\FilteredMetadata\HttpResponseParserFactory;
+use SCI\FilteredMetadata\MediaWikiHttpRequest;
 use SCI\Specials\CitableMetadata\PageBuilder;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 
@@ -112,13 +112,13 @@ class SpecialFindCitableMetadata extends SpecialPage {
 			$this->getLanguage()
 		);
 
-		$httpRequestFactory = new HttpRequestFactory(
+		$httpRequest = new MediaWikiHttpRequest(
+			MediaWikiServices::getInstance()->getHttpRequestFactory(),
 			\SemanticCite::newCompositeCache( $GLOBALS['scigMetadataResponseCacheType'] )
 		);
 
-		$httpRequest = $httpRequestFactory->newCachedCurlRequest();
-		$httpRequest->setOption( ONOI_HTTP_REQUEST_RESPONSECACHE_TTL, $GLOBALS['scigMetadataResponseCacheLifetime'] );
-		$httpRequest->setOption( ONOI_HTTP_REQUEST_RESPONSECACHE_PREFIX, $GLOBALS['scigCachePrefix'] . ':sci:meta:' );
+		$httpRequest->setOption( MediaWikiHttpRequest::RESPONSE_CACHE_TTL, $GLOBALS['scigMetadataResponseCacheLifetime'] );
+		$httpRequest->setOption( MediaWikiHttpRequest::RESPONSE_CACHE_PREFIX, $GLOBALS['scigCachePrefix'] . ':sci:meta:' );
 
 		$pageBuilder = new PageBuilder(
 			$htmlFormRenderer,

--- a/tests/phpunit/Integration/FilteredMetadata/SciteTransclusionForCannedResponseParserTest.php
+++ b/tests/phpunit/Integration/FilteredMetadata/SciteTransclusionForCannedResponseParserTest.php
@@ -225,7 +225,7 @@ class SciteTransclusionForCannedResponseParserTest extends \PHPUnit\Framework\Te
 
 		$expected = str_replace( "\r\n", "\n", file_get_contents( $expectedResultFile ) );
 
-		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+		$httpRequest = $this->getMockBuilder( '\SCI\FilteredMetadata\HttpRequest' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Integration/JSONScript/SemanticCiteJsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/SemanticCiteJsonTestCaseScriptRunnerTest.php
@@ -4,7 +4,6 @@ namespace SCI\Tests\Integration\JSONScript;
 
 use MediaWiki\Context\RequestContext;
 use MediaWiki\Parser\ParserOptions;
-use Onoi\Cache\CacheFactory;
 use SCI\HookRegistry;
 use SCI\MediaWikiNsContentMapper;
 use SCI\Options;
@@ -12,6 +11,7 @@ use SMW\DataItems\WikiPage;
 use SMW\Tests\JSONScriptServicesTestCaseRunner;
 use SMW\Tests\Utils\JSONScript\JsonTestCaseFileHandler;
 use SMW\Tests\Utils\UtilityFactory;
+use Wikimedia\ObjectCache\HashBagOStuff;
 
 /**
  * @group semantic-cite
@@ -65,11 +65,9 @@ class SemanticCiteJsonTestCaseScriptRunnerTest extends JSONScriptServicesTestCas
 		MediaWikiNsContentMapper::clear();
 		MediaWikiNsContentMapper::$skipMessageCache = true;
 
-		$cacheFactory = new CacheFactory();
-
 		$this->hookRegistry = new HookRegistry(
 			$this->getStore(),
-			$cacheFactory->newFixedInMemoryLruCache(),
+			new HashBagOStuff(),
 			new Options( $configuration )
 		);
 

--- a/tests/phpunit/Unit/CachedReferenceListOutputRendererTest.php
+++ b/tests/phpunit/Unit/CachedReferenceListOutputRendererTest.php
@@ -34,7 +34,7 @@ class CachedReferenceListOutputRendererTest extends \PHPUnit\Framework\TestCase 
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$this->cache = $this->getMockBuilder( '\Wikimedia\ObjectCache\BagOStuff' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/CitationReferencePositionJournalTest.php
+++ b/tests/phpunit/Unit/CitationReferencePositionJournalTest.php
@@ -20,7 +20,7 @@ class CitationReferencePositionJournalTest extends \PHPUnit\Framework\TestCase {
 	private $cacheKeyProvider;
 
 	protected function setUp(): void {
-		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$this->cache = $this->getMockBuilder( '\Wikimedia\ObjectCache\BagOStuff' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/FilteredMetadata/BibliographicFilteredRecordTest.php
+++ b/tests/phpunit/Unit/FilteredMetadata/BibliographicFilteredRecordTest.php
@@ -17,7 +17,7 @@ class BibliographicFilteredRecordTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
-			'\Onoi\Remi\FilteredRecord',
+			'\SCI\FilteredMetadata\FilteredRecord',
 			new BibliographicFilteredRecord()
 		);
 	}

--- a/tests/phpunit/Unit/FilteredMetadata/CrossRefResponseParserTest.php
+++ b/tests/phpunit/Unit/FilteredMetadata/CrossRefResponseParserTest.php
@@ -16,18 +16,18 @@ use SCI\FilteredMetadata\CrossRefResponseParser;
 class CrossRefResponseParserTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCanConstruct() {
-		$crossRefFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\CrossRef\CrossRefFilteredHttpResponseParser' )
+		$crossRefFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\CrossRef\CrossRefFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\Onoi\Remi\ResponseParser',
+			'\SCI\FilteredMetadata\ResponseParser',
 			new CrossRefResponseParser( $crossRefFilteredHttpResponseParser )
 		);
 	}
 
 	public function testInterfaceMethods() {
-		$crossRefFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\CrossRef\CrossRefFilteredHttpResponseParser' )
+		$crossRefFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\CrossRef\CrossRefFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -58,7 +58,7 @@ class CrossRefResponseParserTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$crossRefFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\CrossRef\CrossRefFilteredHttpResponseParser' )
+		$crossRefFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\CrossRef\CrossRefFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/FilteredMetadata/HttpResponseParserFactoryTest.php
+++ b/tests/phpunit/Unit/FilteredMetadata/HttpResponseParserFactoryTest.php
@@ -16,7 +16,7 @@ use SCI\FilteredMetadata\HttpResponseParserFactory;
 class HttpResponseParserFactoryTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCanConstruct() {
-		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+		$httpRequest = $this->getMockBuilder( '\SCI\FilteredMetadata\HttpRequest' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -30,14 +30,14 @@ class HttpResponseParserFactoryTest extends \PHPUnit\Framework\TestCase {
 	 * @dataProvider typeProvider
 	 */
 	public function testHttpResponseContentParserForType( $type ) {
-		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+		$httpRequest = $this->getMockBuilder( '\SCI\FilteredMetadata\HttpRequest' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new HttpResponseParserFactory( $httpRequest );
 
 		$this->assertInstanceOf(
-			'\Onoi\Remi\ResponseParser',
+			'\SCI\FilteredMetadata\ResponseParser',
 			$instance->newResponseParserForType( $type )
 		);
 	}

--- a/tests/phpunit/Unit/FilteredMetadata/MediaWikiHttpRequestTest.php
+++ b/tests/phpunit/Unit/FilteredMetadata/MediaWikiHttpRequestTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace SCI\Tests\FilteredMetadata;
+
+use MediaWiki\Status\Status;
+use SCI\FilteredMetadata\HttpRequest;
+use SCI\FilteredMetadata\MediaWikiHttpRequest;
+use Wikimedia\ObjectCache\HashBagOStuff;
+
+/**
+ * @covers \SCI\FilteredMetadata\MediaWikiHttpRequest
+ * @group semantic-cite
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0
+ *
+ * @author mwjames
+ */
+class MediaWikiHttpRequestTest extends \PHPUnit\Framework\TestCase {
+
+	private function newHttpRequestFactory() {
+		return $this->getMockBuilder( '\MediaWiki\Http\HttpRequestFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	private function newMwHttpRequest( $status, $content, $httpCode = 200 ) {
+		$mwRequest = $this->getMockBuilder( '\MWHttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mwRequest->method( 'execute' )->willReturn( $status );
+		$mwRequest->method( 'getContent' )->willReturn( $content );
+		$mwRequest->method( 'getStatus' )->willReturn( $httpCode );
+
+		return $mwRequest;
+	}
+
+	private function newStatus( $isOK ) {
+		$status = $this->createMock( Status::class );
+		$status->method( 'isOK' )->willReturn( $isOK );
+
+		return $status;
+	}
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			MediaWikiHttpRequest::class,
+			new MediaWikiHttpRequest( $this->newHttpRequestFactory(), new HashBagOStuff() )
+		);
+	}
+
+	public function testExecuteReturnsContentAndCachesSuccessfulResponse() {
+		$mwRequest = $this->newMwHttpRequest( $this->newStatus( true ), '{"ok":1}' );
+
+		$httpRequestFactory = $this->newHttpRequestFactory();
+
+		// create() is invoked only once: the second execute is served from the
+		// response cache.
+		$httpRequestFactory->expects( $this->once() )
+			->method( 'create' )
+			->willReturn( $mwRequest );
+
+		$instance = new MediaWikiHttpRequest( $httpRequestFactory, new HashBagOStuff() );
+
+		$instance->setOption( HttpRequest::URL, 'https://example.org/x' );
+		$this->assertSame( '{"ok":1}', $instance->execute() );
+		$this->assertFalse( $instance->isCached() );
+		$this->assertSame( '', $instance->getLastError() );
+
+		$instance->setOption( HttpRequest::URL, 'https://example.org/x' );
+		$this->assertSame( '{"ok":1}', $instance->execute() );
+		$this->assertTrue( $instance->isCached() );
+	}
+
+	public function testFailedResponseIsNotCachedAndReportsError() {
+		$mwRequest = $this->newMwHttpRequest( $this->newStatus( false ), '', 404 );
+
+		$httpRequestFactory = $this->newHttpRequestFactory();
+
+		// create() is invoked on every execute because a failed response is
+		// never cached.
+		$httpRequestFactory->expects( $this->exactly( 2 ) )
+			->method( 'create' )
+			->willReturn( $mwRequest );
+
+		$instance = new MediaWikiHttpRequest( $httpRequestFactory, new HashBagOStuff() );
+
+		$instance->setOption( HttpRequest::URL, 'https://example.org/missing' );
+		$instance->execute();
+		$this->assertNotSame( '', $instance->getLastError() );
+		$this->assertFalse( $instance->isCached() );
+
+		$instance->setOption( HttpRequest::URL, 'https://example.org/missing' );
+		$instance->execute();
+		$this->assertFalse( $instance->isCached() );
+	}
+
+	public function testPostOptionsArePassedToTheFactory() {
+		$mwRequest = $this->newMwHttpRequest( $this->newStatus( true ), 'OK' );
+
+		$httpRequestFactory = $this->newHttpRequestFactory();
+
+		$httpRequestFactory->expects( $this->once() )
+			->method( 'create' )
+			->with(
+				'https://eutils.example.org/',
+				$this->callback( static function ( $options ) {
+					return ( $options['method'] ?? null ) === 'POST'
+						&& ( $options['postData'] ?? null ) === 'db=pubmed&id=1';
+				} ),
+				$this->anything()
+			)
+			->willReturn( $mwRequest );
+
+		$instance = new MediaWikiHttpRequest( $httpRequestFactory, new HashBagOStuff() );
+
+		$instance->setOption( HttpRequest::URL, 'https://eutils.example.org/' );
+		$instance->setOption( HttpRequest::POST, true );
+		$instance->setOption( HttpRequest::POST_FIELDS, 'db=pubmed&id=1' );
+
+		$this->assertSame( 'OK', $instance->execute() );
+	}
+
+	public function testHeadersAreParsedAndForwarded() {
+		$mwRequest = $this->newMwHttpRequest( $this->newStatus( true ), 'OK' );
+
+		$headers = [];
+
+		// Two well-formed headers are forwarded; a header without a colon is
+		// skipped, so setHeader() is called exactly twice.
+		$mwRequest->expects( $this->exactly( 2 ) )
+			->method( 'setHeader' )
+			->willReturnCallback( static function ( $name, $value ) use ( &$headers ) {
+				$headers[$name] = $value;
+			} );
+
+		$httpRequestFactory = $this->newHttpRequestFactory();
+		$httpRequestFactory->method( 'create' )->willReturn( $mwRequest );
+
+		$instance = new MediaWikiHttpRequest( $httpRequestFactory, new HashBagOStuff() );
+
+		$instance->setOption( HttpRequest::URL, 'https://example.org/x' );
+		$instance->setOption( HttpRequest::HEADERS, [
+			'Accept: application/json',
+			'Content-Type: text/plain; charset=UTF-8',
+			'MalformedHeaderWithoutColon',
+		] );
+
+		$this->assertSame( 'OK', $instance->execute() );
+		$this->assertSame( 'application/json', $headers['Accept'] );
+		$this->assertSame( 'text/plain; charset=UTF-8', $headers['Content-Type'] );
+	}
+
+}

--- a/tests/phpunit/Unit/FilteredMetadata/NcbiPubMedResponseParserTest.php
+++ b/tests/phpunit/Unit/FilteredMetadata/NcbiPubMedResponseParserTest.php
@@ -16,18 +16,18 @@ use SCI\FilteredMetadata\NcbiPubMedResponseParser;
 class NcbiPubMedResponseParserTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCanConstruct() {
-		$ncbiPubMedFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\Ncbi\NcbiPubMedFilteredHttpResponseParser' )
+		$ncbiPubMedFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\Ncbi\NcbiPubMedFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\Onoi\Remi\ResponseParser',
+			'\SCI\FilteredMetadata\ResponseParser',
 			new NcbiPubMedResponseParser( $ncbiPubMedFilteredHttpResponseParser )
 		);
 	}
 
 	public function testInterfaceMethods() {
-		$ncbiPubMedFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\Ncbi\NcbiPubMedFilteredHttpResponseParser' )
+		$ncbiPubMedFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\Ncbi\NcbiPubMedFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -63,7 +63,7 @@ class NcbiPubMedResponseParserTest extends \PHPUnit\Framework\TestCase {
 			->with( $this->stringContains( 'ncbi-dbtype' ) )
 			->willReturn( $type );
 
-		$ncbiPubMedFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\Ncbi\NcbiPubMedFilteredHttpResponseParser' )
+		$ncbiPubMedFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\Ncbi\NcbiPubMedFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/FilteredMetadata/OLResponseParserTest.php
+++ b/tests/phpunit/Unit/FilteredMetadata/OLResponseParserTest.php
@@ -16,18 +16,18 @@ use SCI\FilteredMetadata\OLResponseParser;
 class OLResponseParserTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCanConstruct() {
-		$olFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\OpenLibrary\OLFilteredHttpResponseParser' )
+		$olFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\OpenLibrary\OLFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\Onoi\Remi\ResponseParser',
+			'\SCI\FilteredMetadata\ResponseParser',
 			new OLResponseParser( $olFilteredHttpResponseParser )
 		);
 	}
 
 	public function testInterfaceMethods() {
-		$olFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\OpenLibrary\OLFilteredHttpResponseParser' )
+		$olFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\OpenLibrary\OLFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -58,7 +58,7 @@ class OLResponseParserTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$olFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\OpenLibrary\OLFilteredHttpResponseParser' )
+		$olFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\OpenLibrary\OLFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/FilteredMetadata/OclcResponseParserTest.php
+++ b/tests/phpunit/Unit/FilteredMetadata/OclcResponseParserTest.php
@@ -16,18 +16,18 @@ use SCI\FilteredMetadata\OclcResponseParser;
 class OclcResponseParserTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCanConstruct() {
-		$oclcNumFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\Oclc\OclcFilteredHttpResponseParser' )
+		$oclcNumFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\Oclc\OclcFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\Onoi\Remi\ResponseParser',
+			'\SCI\FilteredMetadata\ResponseParser',
 			new OclcResponseParser( $oclcNumFilteredHttpResponseParser )
 		);
 	}
 
 	public function testInterfaceMethods() {
-		$oclcFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\Oclc\OclcFilteredHttpResponseParser' )
+		$oclcFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\Oclc\OclcFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -58,7 +58,7 @@ class OclcResponseParserTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$oclcFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\Oclc\OclcFilteredHttpResponseParser' )
+		$oclcFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\Oclc\OclcFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/FilteredMetadata/ViafResponseParserTest.php
+++ b/tests/phpunit/Unit/FilteredMetadata/ViafResponseParserTest.php
@@ -16,18 +16,18 @@ use SCI\FilteredMetadata\ViafResponseParser;
 class ViafResponseParserTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCanConstruct() {
-		$viafFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\Viaf\ViafFilteredHttpResponseParser' )
+		$viafFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\Viaf\ViafFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\Onoi\Remi\ResponseParser',
+			'\SCI\FilteredMetadata\ResponseParser',
 			new ViafResponseParser( $viafFilteredHttpResponseParser )
 		);
 	}
 
 	public function testInterfaceMethods() {
-		$viafFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\Viaf\ViafFilteredHttpResponseParser' )
+		$viafFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\Viaf\ViafFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -58,7 +58,7 @@ class ViafResponseParserTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$viafFilteredHttpResponseParser = $this->getMockBuilder( '\Onoi\Remi\Viaf\ViafFilteredHttpResponseParser' )
+		$viafFilteredHttpResponseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\Viaf\ViafFilteredHttpResponseParser' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -25,7 +25,7 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( '\Wikimedia\ObjectCache\BagOStuff' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
@@ -44,7 +44,7 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( '\Wikimedia\ObjectCache\BagOStuff' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 

--- a/tests/phpunit/Unit/ReferenceListFactoryTest.php
+++ b/tests/phpunit/Unit/ReferenceListFactoryTest.php
@@ -59,7 +59,7 @@ class ReferenceListFactoryTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( '\Wikimedia\ObjectCache\BagOStuff' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/Specials/CitableMetadata/HtmlResponseParserRendererTest.php
+++ b/tests/phpunit/Unit/Specials/CitableMetadata/HtmlResponseParserRendererTest.php
@@ -16,7 +16,7 @@ use SCI\Specials\CitableMetadata\HtmlResponseParserRenderer;
 class HtmlResponseParserRendererTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCanConstruct() {
-		$responseParser = $this->getMockBuilder( '\Onoi\Remi\ResponseParser' )
+		$responseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\ResponseParser' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
@@ -27,7 +27,7 @@ class HtmlResponseParserRendererTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testGetRawResponse() {
-		$responseParser = $this->getMockBuilder( '\Onoi\Remi\ResponseParser' )
+		$responseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\ResponseParser' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
@@ -47,7 +47,7 @@ class HtmlResponseParserRendererTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$responseParser = $this->getMockBuilder( '\Onoi\Remi\ResponseParser' )
+		$responseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\ResponseParser' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 

--- a/tests/phpunit/Unit/Specials/CitableMetadata/PageBuilderTest.php
+++ b/tests/phpunit/Unit/Specials/CitableMetadata/PageBuilderTest.php
@@ -53,7 +53,7 @@ class PageBuilderTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testGetRawResponse() {
-		$responseParser = $this->getMockBuilder( '\Onoi\Remi\ResponseParser' )
+		$responseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\ResponseParser' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
@@ -81,7 +81,7 @@ class PageBuilderTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$responseParser = $this->getMockBuilder( '\Onoi\Remi\ResponseParser' )
+		$responseParser = $this->getMockBuilder( '\SCI\FilteredMetadata\ResponseParser' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 


### PR DESCRIPTION
## Summary

Removes Semantic Cite's three external `onoi`-family Composer dependencies in favour of MediaWiki built-ins.

| Dependency | Replacement |
|---|---|
| `onoi/cache` | `Wikimedia\ObjectCache\BagOStuff` / `CachedBagOStuff` |
| `mediawiki/http-request` (`Onoi\HttpRequest`) | `MediaWiki\Http\HttpRequestFactory` |
| `onoi/remi` | **vendored** into `SCI\FilteredMetadata\` (no MediaWiki equivalent exists) |

These were coupled: `onoi/remi` depends on `onoi/http-request`, so the HTTP package could only be dropped by also internalising `onoi/remi`.

## Details

- **Cache** — `SemanticCite::newCompositeCache()` now returns a `CachedBagOStuff` (an in-process layer, `maxKeys = 500`, over the configured object cache), replacing the onoi composite. Call sites remapped `fetch→get`, `save→set`, `contains→get() !== false`, `delete→delete`.
- **HTTP** — new `SCI\FilteredMetadata\MediaWikiHttpRequest` (implements `SCI\FilteredMetadata\HttpRequest`) wraps `HttpRequestFactory` and preserves the 24 h metadata **response cache** (TTL + prefix) over a `BagOStuff`; failed responses are not cached.
- **remi** — `onoi/remi` is a set of bibliographic REST parsers (CrossRef, VIAF, OCLC, PubMed, OpenLibrary) with no MediaWiki equivalent, so its parsers were vendored verbatim under `SCI\FilteredMetadata\` (provider sub-namespaces preserved); only their cURL HTTP layer was rewritten to the new client. The `onoi-remi-*` i18n **message keys** are intentionally kept so existing translations keep working.

## Behaviour change worth noting

The bundled parsers **no longer skip TLS certificate verification**. The former `onoi/remi` parsers set `CURLOPT_SSL_VERIFYPEER = false` for CrossRef / NCBI / OpenLibrary; requests now verify normally through MediaWiki's HTTP stack. These are valid-certificate HTTPS endpoints, so this should be a no-op in practice while removing the MITM exposure.

## Verification

- ✅ `composer lint` (parallel-lint), `composer phpcs` (MediaWiki standard), `composer minus-x`, `composer validate`
- ✅ Multi-agent adversarial review diffing the port against the original onoi sources — no correctness issues
- ✅ Standalone smoke test of the new HTTP client (caching / error handling / option mapping) and the vendored CrossRef parser pipeline
