### PR TITLE
Use 7.x-dev branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.0.0-dev"
+			"dev-master": "7.x-dev"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
The `dev-master` branch develops the 7.x line, so its Composer branch alias should be `7.x-dev` — the form Semantic MediaWiki core uses.

`7.0.0-dev` pins the alias to a single patch release, and it does not satisfy a `^7.0` / `~7.0` constraint while `master` is still untagged during the 7.0 pre-release period — which is exactly when a branch alias does its job (giving the untagged branch a semver-resolvable identity). `7.x-dev` resolves cleanly against `^7.0` and matches the rest of the Semantic MediaWiki stack.
