### PR TITLE
Use strict semantic versioning for the version number

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,9 +1,6 @@
 This file contains the RELEASE-NOTES of the **Semantic Cite** (a.k.a. SCI) extension.
 
-## 7.0.0
-
-Note: the version was bumped from 4.0.0 directly to 7.0.0 to track the Semantic
-MediaWiki major release it supports; versions 5.x and 6.x were skipped.
+## 5.0.0
 
 * Minimum requirement for Semantic MediaWiki changed to version 7.0 and later
 * Added compatibility with Semantic MediaWiki 7.0.x

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.x-dev"
+			"dev-master": "5.x-dev"
 		}
 	},
 	"autoload": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticCite",
-	"version": "7.0.0-alpha",
+	"version": "5.0.0-alpha",
 	"author": [
         	"James Hong Kong"
 	],


### PR DESCRIPTION
## Summary

Adopt semantic versioning for the **SemanticCite** version number. Versioning the extension independently of Semantic MediaWiki lets it introduce its own breaking changes mid-cycle — between Semantic MediaWiki major releases — instead of holding them to realign its major with the next Semantic MediaWiki major.

This sets the version to the extension's own next major, `5.0.0-alpha` (branch-alias `5.x-dev`), rather than tracking the Semantic MediaWiki major. The `SemanticMediaWiki >= 7.0` requirement (the Semantic MediaWiki version this release targets) is unchanged.

## Changes

- `extension.json`: version → `5.0.0-alpha`
- `composer.json`: `extra.branch-alias.dev-master` → `5.x-dev`
- `RELEASE-NOTES.md`: heading → `5.0.0`, and drop the note that described the version tracking / mirroring the Semantic MediaWiki major
- `@since 7.0.0` docblocks updated to `@since 5.0.0` where present
